### PR TITLE
change url of openbugs from openbugs.info to openbugs.net

### DIFF
--- a/bugs_examples/README.txt
+++ b/bugs_examples/README.txt
@@ -4,7 +4,7 @@ This folder contains WinBUGS examples in Stan. The descriptions can be found at:
  http://www.mrc-bsu.cam.ac.uk/bugs/winbugs/Vol3.pdf
 
 OpenBUGS examples: 
- http://www.openbugs.info/w/Examples
+ http://www.openbugs.net/w/Examples
  http://mathstat.helsinki.fi/openbugs/ExamplesFrames.html
 
 JAGS models and data for all these examples are in:

--- a/bugs_examples/vol1/blocker/blocker.stan
+++ b/bugs_examples/vol1/blocker/blocker.stan
@@ -1,4 +1,4 @@
-#DOC See \url{http://www.openbugs.info/Examples/Blockers.html}.
+#DOC See \url{http://www.openbugs.net/Examples/Blockers.html}.
 data {
   int<lower=0> N; 
   int<lower=0> nt[N]; 

--- a/bugs_examples/vol1/bones/bones.stan
+++ b/bugs_examples/vol1/bones/bones.stan
@@ -1,7 +1,7 @@
 /**
  * Bones: latent trait model for multiple ordered 
  * categorical responses 
- * http://www.openbugs.info/Examples/Bones.html
+ * http://www.openbugs.net/Examples/Bones.html
  *
  *
  * Note: 

--- a/bugs_examples/vol1/dyes/dyes.stan
+++ b/bugs_examples/vol1/dyes/dyes.stan
@@ -1,5 +1,5 @@
 # Dyes: variance components model 
-#  http://www.openbugs.info/Examples/Dyes.html
+#  http://www.openbugs.net/Examples/Dyes.html
 
 data {
   int BATCHES; 

--- a/bugs_examples/vol1/equiv/equiv.stan
+++ b/bugs_examples/vol1/equiv/equiv.stan
@@ -1,5 +1,5 @@
 # Equiv: bioequivalence in a cross-over trial
-#  http://www.openbugs.info/Examples/Equiv.html
+#  http://www.openbugs.net/Examples/Equiv.html
 
 data {
   int<lower=0> P; 

--- a/bugs_examples/vol1/inhalers/inhalers.stan
+++ b/bugs_examples/vol1/inhalers/inhalers.stan
@@ -1,5 +1,5 @@
 # Inhaler: ordered categorical data 
-## http://www.openbugs.info/Examples/Inhalers.html
+## http://www.openbugs.net/Examples/Inhalers.html
 
 ## FIXME ii: 
 ## specify using categorical distribution directly 

--- a/bugs_examples/vol1/kidney/kidney.stan
+++ b/bugs_examples/vol1/kidney/kidney.stan
@@ -1,6 +1,6 @@
 # http://www.mrc-bsu.cam.ac.uk/bugs/winbugs/Vol1.pdf
 # Page 51: Kidney: Weibull regression with random efects
-# http://www.openbugs.info/Examples/Kidney.html
+# http://www.openbugs.net/Examples/Kidney.html
 
 data {
   int<lower=0> NP; 

--- a/bugs_examples/vol1/leuk/leuk.stan
+++ b/bugs_examples/vol1/leuk/leuk.stan
@@ -1,7 +1,7 @@
 /*
  * Leuk: Cox regression 
  * URL of OpenBugs' implementation: 
- *   http://www.openbugs.info/Examples/Leuk.html
+ *   http://www.openbugs.net/Examples/Leuk.html
  */
 
 data {

--- a/bugs_examples/vol1/leuk/leuk.stan.0
+++ b/bugs_examples/vol1/leuk/leuk.stan.0
@@ -1,6 +1,6 @@
 # Leuk: Cox regression 
 # URL of OpenBugs' implementation: 
-#   http://www.openbugs.info/Examples/Leuk.html
+#   http://www.openbugs.net/Examples/Leuk.html
 data {
   int<lower=0> N;
   int<lower=0> NT;

--- a/bugs_examples/vol1/leukfr/leukfr.stan
+++ b/bugs_examples/vol1/leukfr/leukfr.stan
@@ -1,7 +1,7 @@
 /*
  * BUGS example vol 1: LeukFr 
  * http://mathstat.helsinki.fi/openbugs/Examples/Leukfr.html
- *  http://www.openbugs.info/Examples/Leukfr.html
+ *  http://www.openbugs.net/Examples/Leukfr.html
  *
  * The result for sigma is a bit different from those in the 
  * webpage. 

--- a/bugs_examples/vol1/leukfr/leukfr.stan.0
+++ b/bugs_examples/vol1/leukfr/leukfr.stan.0
@@ -1,6 +1,6 @@
 # BUGS example vol 1: LeukFr 
 # http://mathstat.helsinki.fi/openbugs/Examples/Leukfr.html
-#  http://www.openbugs.info/Examples/Leukfr.html
+#  http://www.openbugs.net/Examples/Leukfr.html
 
 # The result for sigma is a bit different from those in the 
 # webpage. 

--- a/bugs_examples/vol1/lsat/lsat.stan
+++ b/bugs_examples/vol1/lsat/lsat.stan
@@ -1,5 +1,5 @@
 # LSAT: item response
-# http://www.openbugs.info/Examples/Lsat.html
+# http://www.openbugs.net/Examples/Lsat.html
 
 data {
   int<lower=0> N; // 1000, number of students

--- a/bugs_examples/vol1/magnesium/magnesium.stan
+++ b/bugs_examples/vol1/magnesium/magnesium.stan
@@ -1,5 +1,5 @@
 # Sensitivity to prior distributions: application to Magnesium meta-analysis
-#  http://www.openbugs.info/Examples/Magnesium.html
+#  http://www.openbugs.net/Examples/Magnesium.html
 
 # prior specification 1, 2, 3, 4, 5, and 6 combined  
 # in one posterior distribution.  

--- a/bugs_examples/vol1/mice/mice.stan
+++ b/bugs_examples/vol1/mice/mice.stan
@@ -1,6 +1,6 @@
 # http://www.mrc-bsu.cam.ac.uk/bugs/winbugs/Vol1.pdf
 # Page 48: Mice Weibull regression 
-# http://www.openbugs.info/Examples/Mice.html
+# http://www.openbugs.net/Examples/Mice.html
 
 # note that Stan and JAGS have different parameterization for Weibull
 # distribution

--- a/bugs_examples/vol1/salm/salm.stan
+++ b/bugs_examples/vol1/salm/salm.stan
@@ -1,4 +1,4 @@
-##  http://www.openbugs.info/Examples/Salm.html
+##  http://www.openbugs.net/Examples/Salm.html
 ##  this matches the jags implementation
 data {
     int<lower=0> Ndoses;

--- a/bugs_examples/vol1/salm/salm2.stan
+++ b/bugs_examples/vol1/salm/salm2.stan
@@ -1,4 +1,4 @@
-##  http://www.openbugs.info/Examples/Salm.html
+##  http://www.openbugs.net/Examples/Salm.html
 
 ## the version without centering x's 
 data {

--- a/bugs_examples/vol1/seeds/seeds.stan
+++ b/bugs_examples/vol1/seeds/seeds.stan
@@ -1,5 +1,5 @@
 ## 
-##  http://www.openbugs.info/Examples/Seeds.html
+##  http://www.openbugs.net/Examples/Seeds.html
 data {
     int<lower=0> I;
     int<lower=0> n[I];

--- a/bugs_examples/vol1/surgical/surgical.stan
+++ b/bugs_examples/vol1/surgical/surgical.stan
@@ -1,4 +1,4 @@
-## http://openbugs.info/Examples/Surgical.html
+## http://openbugs.net/Examples/Surgical.html
 ## random effects model 
 data {
   int<lower=0> N;

--- a/bugs_examples/vol2/alli/alli1.stan.old
+++ b/bugs_examples/vol2/alli/alli1.stan.old
@@ -1,6 +1,6 @@
 
 # Alligators: multinomial - logistic regression 
-#  http://www.openbugs.info/Examples/Aligators.html
+#  http://www.openbugs.net/Examples/Aligators.html
 
 ## specify the model using multinomial distribution 
 

--- a/bugs_examples/vol2/alli/alli2.stan
+++ b/bugs_examples/vol2/alli/alli2.stan
@@ -1,5 +1,5 @@
 # Alligators: multinomial - logistic regression 
-#  http://www.openbugs.info/Examples/Aligators.html
+#  http://www.openbugs.net/Examples/Aligators.html
 
 ## specify the model using Poisson distribution 
 

--- a/bugs_examples/vol2/biopsies/biopsies.stan.0
+++ b/bugs_examples/vol2/biopsies/biopsies.stan.0
@@ -1,1 +1,1 @@
-# http://www.openbugs.info/Examples/Biopsies.html
+# http://www.openbugs.net/Examples/Biopsies.html

--- a/bugs_examples/vol2/cervix/cervix.stan.0
+++ b/bugs_examples/vol2/cervix/cervix.stan.0
@@ -1,6 +1,6 @@
 
 # Cervix: case - control study with errors in covariates 
-#  http://www.openbugs.info/Examples/Cervix.html
+#  http://www.openbugs.net/Examples/Cervix.html
 
 # from the JAGS readme in classic-bugs/vol2/cervix:
 

--- a/bugs_examples/vol2/cervix/cervix2.stan
+++ b/bugs_examples/vol2/cervix/cervix2.stan
@@ -1,5 +1,5 @@
 # Cervix: case - control study with errors in covariates 
-#  http://www.openbugs.info/Examples/Cervix.html
+#  http://www.openbugs.net/Examples/Cervix.html
 
 # from the JAGS readme in classic-bugs/vol2/cervix:
 

--- a/bugs_examples/vol2/endo/endo1.stan
+++ b/bugs_examples/vol2/endo/endo1.stan
@@ -1,5 +1,5 @@
 # Endo: conditional inference in case-contrl studies 
-# http://www.openbugs.info/Examples/Endo.html
+# http://www.openbugs.net/Examples/Endo.html
 
 # In this example, three methods of different 
 # model specifications are used for one equivalent

--- a/bugs_examples/vol2/endo/endo2.stan
+++ b/bugs_examples/vol2/endo/endo2.stan
@@ -1,6 +1,6 @@
 /*
  * Endo: conditional inference in case-contrl studies 
- * http://www.openbugs.info/Examples/Endo.html
+ * http://www.openbugs.net/Examples/Endo.html
  *
  * In this example, three methods of different 
  * model specifications are used for one equivalent

--- a/bugs_examples/vol2/endo/endo3.stan
+++ b/bugs_examples/vol2/endo/endo3.stan
@@ -1,5 +1,5 @@
 # Endo: conditional inference in case-contrl studies 
-# http://www.openbugs.info/Examples/Endo.html
+# http://www.openbugs.net/Examples/Endo.html
 
 # In this example, three methods of different 
 # model specifications are used for one equivalent

--- a/bugs_examples/vol2/hearts/hearts.stan
+++ b/bugs_examples/vol2/hearts/hearts.stan
@@ -1,6 +1,6 @@
 /**
  * Hearts: a mixture model for count data
- * http://www.openbugs.info/Examples/Hearts.html
+ * http://www.openbugs.net/Examples/Hearts.html
  * 
  * integrate out the binary parameters in hearts.stan.0 
  */

--- a/bugs_examples/vol2/hearts/hearts.stan.0
+++ b/bugs_examples/vol2/hearts/hearts.stan.0
@@ -1,5 +1,5 @@
 # Hearts: a mixture model for count data
-# http://www.openbugs.info/Examples/Hearts.html
+# http://www.openbugs.net/Examples/Hearts.html
 # 
 
 ## status: not work (there are discrete parameters) 

--- a/bugs_examples/vol2/jaws/jaws.stan
+++ b/bugs_examples/vol2/jaws/jaws.stan
@@ -1,5 +1,5 @@
 # Jaws: repeated measures analysis of variance
-#  http://www.openbugs.info/Examples/Jaws.html
+#  http://www.openbugs.net/Examples/Jaws.html
 
 data {
   int<lower=0> N; 

--- a/bugs_examples/vol2/mvn_orange/mvn_orange.stan
+++ b/bugs_examples/vol2/mvn_orange/mvn_orange.stan
@@ -1,5 +1,5 @@
 // Orange Trees (Multi-variate normal) 
-// http://www.openbugs.info/Examples/OtreesMVN.html
+// http://www.openbugs.net/Examples/OtreesMVN.html
 // and refer to ../orange 
 
 # FIXME: there are some discrepancy for parameters var 

--- a/bugs_examples/vol2/orange/orange.stan
+++ b/bugs_examples/vol2/orange/orange.stan
@@ -1,5 +1,5 @@
 // Orange Trees 
-// http://www.openbugs.info/Examples/Otrees.html
+// http://www.openbugs.net/Examples/Otrees.html
 
 # status: error thrown out during execution immediately 
 

--- a/bugs_examples/vol2/schools/schools.stan
+++ b/bugs_examples/vol2/schools/schools.stan
@@ -1,7 +1,7 @@
 
 # Schools: ranking school examination resutls using 
 # multivariate hierarcical models 
-#  http://www.openbugs.info/Examples/Schools.html
+#  http://www.openbugs.net/Examples/Schools.html
 
 data {
   int<lower=0> N; 

--- a/bugs_examples/vol2/t_df/estdof.stan
+++ b/bugs_examples/vol2/t_df/estdof.stan
@@ -1,7 +1,7 @@
 
 ## estimated the degree of freedom (dof) from 
 ## samples by sim.stan
-# http://www.openbugs.info/Examples/t-df.html
+# http://www.openbugs.net/Examples/t-df.html
 
 ## estimate dof using continuous priors 
 

--- a/bugs_examples/vol2/t_df/estdof2.stan.0
+++ b/bugs_examples/vol2/t_df/estdof2.stan.0
@@ -1,7 +1,7 @@
 
 ## estimated the degree of freedom (dof) from 
 ## samples by sim.stan
-# http://www.openbugs.info/Examples/t-df.html
+# http://www.openbugs.net/Examples/t-df.html
 
 ## estimate dof using discrete priors 
 

--- a/bugs_examples/vol2/t_df/simt4.stan
+++ b/bugs_examples/vol2/t_df/simt4.stan
@@ -1,6 +1,6 @@
 ##  simulate samples from student t distribution 
 ## 
-# http://www.openbugs.info/Examples/t-df.html
+# http://www.openbugs.net/Examples/t-df.html
 
 transformed data {
   int d; 

--- a/bugs_examples/vol3/camel/camel.stan
+++ b/bugs_examples/vol3/camel/camel.stan
@@ -1,6 +1,6 @@
 /**
  * Camel: Multivariate normal with structured missing data 
- * http://www.openbugs.info/Examples/Camel.html
+ * http://www.openbugs.net/Examples/Camel.html
  *
  * status: results not verified with in those in bugs 
  */

--- a/bugs_examples/vol3/camel/camel2.stan
+++ b/bugs_examples/vol3/camel/camel2.stan
@@ -1,6 +1,6 @@
 /*
  * Camel: Multivariate normal with structured missing data 
- * http://www.openbugs.info/Examples/Camel.html
+ * http://www.openbugs.net/Examples/Camel.html
  *
  * integrate out the missing data
  */

--- a/bugs_examples/vol3/data_cloning/seeds.stan
+++ b/bugs_examples/vol3/data_cloning/seeds.stan
@@ -1,5 +1,5 @@
 # Using Data Cloning to Calculate MLEs for the Seeds Model in vol1 
-# http://www.openbugs.info/Examples/DataCloning.html
+# http://www.openbugs.net/Examples/DataCloning.html
 
 # The basic idea is that we raise the likelihood in the 
 # posterior to the power of K so that the posterior

--- a/bugs_examples/vol3/fire/fire.stan
+++ b/bugs_examples/vol3/fire/fire.stan
@@ -3,7 +3,7 @@
  *       directly because the composite lognormal-pareto distribution
  *       is not built in.
  *
- *  http://www.openbugs.info/Examples/Fire.html
+ *  http://www.openbugs.net/Examples/Fire.html
  *
  * see D. P. M. Scollnik (2007) 
  * http://www.tandfonline.com/doi/pdf/10.1080/03461230601110447

--- a/bugs_examples/vol3/fire/post.R
+++ b/bugs_examples/vol3/fire/post.R
@@ -7,7 +7,7 @@ post <- read.csv(file = "samples.csv", header = TRUE, comment.char = '#')[, poin
 summary(as.mcmc(post)) 
 
 
-## from http://www.openbugs.info/Examples/Fire.html
+## from http://www.openbugs.net/Examples/Fire.html
 # mean   sd   MC_error   val2.5pc   median   val97.5pc   start   sample
 # alpha   1.328   0.03179   7.257E-4   1.267   1.328   1.392   1001   10000
 # sigma   0.1971   0.01209   5.755E-4   0.1745   0.1966   0.2219   1001   10000

--- a/bugs_examples/vol3/funshapes/circle.stan
+++ b/bugs_examples/vol3/funshapes/circle.stan
@@ -1,6 +1,6 @@
 /*
  * BUGS volume 3, fun shapes, circle
- * http://www.openbugs.info/Examples/Funshapes.html
+ * http://www.openbugs.net/Examples/Funshapes.html
  */
 parameters {
   real<lower=-1,upper=1> x; 

--- a/bugs_examples/vol3/funshapes/hsquare.stan
+++ b/bugs_examples/vol3/funshapes/hsquare.stan
@@ -1,6 +1,6 @@
 /*
  * Hollow Square
- * http://www.openbugs.info/Examples/Funshapes.html
+ * http://www.openbugs.net/Examples/Funshapes.html
  *
  * Transform a uniform rectangle
  *    1234

--- a/bugs_examples/vol3/funshapes/parallelogram.stan
+++ b/bugs_examples/vol3/funshapes/parallelogram.stan
@@ -1,6 +1,6 @@
 /*
  * BUGS Volume 3, funshapes, parallelogram
- * http://www.openbugs.info/Examples/Funshapes.html
+ * http://www.openbugs.net/Examples/Funshapes.html
  */
 parameters {
   real<lower=0,upper=1> x; 

--- a/bugs_examples/vol3/funshapes/squaremc.stan
+++ b/bugs_examples/vol3/funshapes/squaremc.stan
@@ -1,6 +1,6 @@
 /*
  * BUGS Volume 3, funshapes, square minus circle
- * http://www.openbugs.info/Examples/Funshapes.html
+ * http://www.openbugs.net/Examples/Funshapes.html
  *
  * first draw raw samples from diamond-like shape reflected per
  * quadrant, then reflect in transformed parameters

--- a/bugs_examples/vol3/hepatitis/hepatitis.stan
+++ b/bugs_examples/vol3/hepatitis/hepatitis.stan
@@ -1,7 +1,7 @@
 
 # Hepatitis: a normal hierarchical model with measurement 
 # error
-#  http://openbugs.info/Examples/Hepatitis.html
+#  http://openbugs.net/Examples/Hepatitis.html
 
 # In this version the measurement errors are not modeled.  
 # See hepatisisME for the version with measurement errors. 

--- a/bugs_examples/vol3/hepatitis/hepatitisME.stan
+++ b/bugs_examples/vol3/hepatitis/hepatitisME.stan
@@ -1,7 +1,7 @@
 
 # Hepatitis: a normal hierarchical model with measurement 
 # error
-#  http://openbugs.info/Examples/Hepatitis.html
+#  http://openbugs.net/Examples/Hepatitis.html
 
 # model the measurement eror here (compared with hepatitis.stan) 
 

--- a/bugs_examples/vol3/jama/jama.stan.0
+++ b/bugs_examples/vol3/jama/jama.stan.0
@@ -1,4 +1,4 @@
-# http://www.openbugs.info/Examples/Jama.html
+# http://www.openbugs.net/Examples/Jama.html
 # Jama River Valley Ecuador - Radiocarbon calibration with phase information 
 
 # It turns out that the model specified in OpenBUGS 


### PR DESCRIPTION
It seems that the url in the bugs example is not correct for now.  It is updated by using `sed` to replace it with correct one. 
