### PR TITLE
fix openbugs url

### DIFF
--- a/bugs_examples/README.txt
+++ b/bugs_examples/README.txt
@@ -4,7 +4,7 @@ This folder contains WinBUGS examples in Stan. The descriptions can be found at:
  http://www.mrc-bsu.cam.ac.uk/bugs/winbugs/Vol3.pdf
 
 OpenBUGS examples: 
- http://www.openbugs.info/w/Examples
+ http://www.openbugs.net/w/Examples
  http://mathstat.helsinki.fi/openbugs/ExamplesFrames.html
 
 JAGS models and data for all these examples are in:


### PR DESCRIPTION
openbugs.info seems to have disappeared, now at openbugs.net
