### PR TITLE
Fixed bug in ChangeDetection_Stan.R

### DIFF
--- a/Bayesian_Cognitive_Modeling/ParameterEstimation/DataAnalysis/ChangeDetection_Stan.R
+++ b/Bayesian_Cognitive_Modeling/ParameterEstimation/DataAnalysis/ChangeDetection_Stan.R
@@ -57,7 +57,7 @@ parameters <- c("mu", "sigma", "tau")
 
 # The following command calls Stan with specific options.
 # For a detailed description type "?rstan".
-samples <- stan(fit=samples,   
+samples <- stan(model_code=model,   
                 data=data, 
                 init=myinits,  # If not specified, gives random inits
                 pars=parameters,


### PR DESCRIPTION
The function stan wasn't using the model stored in "model" (it was self referencing to sample) and not working in ChangeDetection_Stan.R.
