### PR TITLE
BCM: correlation vectorization fixed

### DIFF
--- a/Bayesian_Cognitive_Modeling/ParameterEstimation/DataAnalysis/Correlation_1_Stan.R
+++ b/Bayesian_Cognitive_Modeling/ParameterEstimation/DataAnalysis/Correlation_1_Stan.R
@@ -38,7 +38,8 @@ model {
   lambda ~ gamma(.001, .001);
   
   // Data
-  x ~ multi_normal(mu, T);
+  for (i in 1:n)
+    x[i] ~ multi_normal(mu, T);
 }"
 
 # Choose a dataset:


### PR DESCRIPTION
The vectorized version of the Pearson correlation example from BCA (Lee
& Wagenmakers, 2013, p.61) doesn’t work, so I replaced it with a for loop.
