### PR TITLE
BPA: fixed inefficient code

### DIFF
--- a/BPA/Ch.03/GLM_Poisson.stan
+++ b/BPA/Ch.03/GLM_Poisson.stan
@@ -4,6 +4,14 @@ data {
   vector[n] year;       // Year
 }
 
+transformed data {
+  vector[n] year_squared;
+  vector[n] year_cubed;
+
+  year_squared <- year .* year;
+  year_cubed <- year .* year .* year;
+}
+
 parameters {
   real<lower=-20,upper=20> alpha;
   real<lower=-10,upper=10> beta1;
@@ -16,8 +24,8 @@ transformed parameters {
 
   log_lambda <- alpha +
                 beta1 * year +
-                beta2 * year .* year +
-                beta3 * year .* year .* year;
+                beta2 * year_squared +
+                beta3 * year_cubed;
 }
 
 model {


### PR DESCRIPTION
I moved 'year .* year' and 'year .* year .* year' into transformed data block.