### PR TITLE
MPT example (Cogn. Model book): removed divergent transitions and added reparameterized models

### DIFF
--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_2_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_2_Stan.R
@@ -37,10 +37,11 @@ transformed parameters {
   vector<lower=0,upper=1>[nsubjs] u;
   matrix[nparams,nparams] rho;
 		
+  vector[nsubjs] deltachat;
+  vector[nsubjs] deltarhat;
+  vector[nsubjs] deltauhat;
+
 	for (i in 1:nsubjs) {
-    vector[nsubjs] deltachat;
-    vector[nsubjs] deltarhat;
-    vector[nsubjs] deltauhat;
     
 		deltachat[i] <- deltahat[i,1];
 		deltarhat[i] <- deltahat[i,2];
@@ -129,6 +130,7 @@ samples_1 <- stan(model_code=model,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 20)
                   # seed=123  # Setting seed; Default is random seed
 )
 
@@ -144,7 +146,7 @@ samples_2 <- stan(fit=samples_1,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  # seed=123  # Setting seed; Default is random seed
+                  control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 20)
 )
 
 k <- response_6
@@ -159,7 +161,7 @@ samples_6 <- stan(fit=samples_1,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  # seed=123  # Setting seed; Default is random seed
+                  control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 20)
 )
 # Now the values for the monitored parameters are in the "samples" object, 
 # ready for inspection.

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_2_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_2_Stan.R
@@ -133,6 +133,8 @@ samples_1 <- stan(model_code=model,
                   control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 20)
                   # seed=123  # Setting seed; Default is random seed
 )
+samples_1
+traceplot(samples_1, pars = c("muc", "mur", "muu", "rho", "sigmac", "sigmar", "sigmau", "lp__"))
 
 k <- response_2
 nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
@@ -148,6 +150,8 @@ samples_2 <- stan(fit=samples_1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
                   control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 20)
 )
+samples_2
+traceplot(samples_2, pars = c("muc", "mur", "muu", "rho", "sigmac", "sigmar", "sigmau", "lp__"))
 
 k <- response_6
 nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
@@ -163,6 +167,8 @@ samples_6 <- stan(fit=samples_1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
                   control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 20)
 )
+samples_6
+traceplot(samples_6, pars = c("muc", "mur", "muu", "rho", "sigmac", "sigmar", "sigmau", "lp__"))
 # Now the values for the monitored parameters are in the "samples" object, 
 # ready for inspection.
 

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_3_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_3_Stan.R
@@ -1,0 +1,237 @@
+# clears workspace: 
+rm(list=ls()) 
+
+library(rstan)
+rstan_options(auto_write = TRUE)
+options(mc.cores = parallel::detectCores())
+
+# model without parameter expansion
+# model with 1. coding section 6.12
+model <- "
+// Multinomial Processing Tree with Latent Traits
+data { 
+  int<lower=1> nsubjs; 
+  int<lower=1> nparams; 
+  int<lower=0,upper=20> k[nsubjs,4];
+}
+transformed data {
+  vector[3] mudeltahat;
+  
+  mudeltahat[1] <- 0;
+  mudeltahat[2] <- 0;
+  mudeltahat[3] <- 0;
+}
+parameters {
+  vector[nparams] deltahat[nsubjs]; 
+  
+  corr_matrix[nparams] Omega;    // prior correlation
+  vector<lower=0>[nparams] tau;  // prior scale
+
+  real muchat;
+  real murhat;
+  real muuhat;
+} 
+transformed parameters {
+  simplex[4] theta[nsubjs];
+  vector<lower=0,upper=1>[nsubjs] c;
+  vector<lower=0,upper=1>[nsubjs] r;
+  vector<lower=0,upper=1>[nsubjs] u;
+    
+  for (i in 1:nsubjs) {
+    vector[nsubjs] deltachat;
+    vector[nsubjs] deltarhat;
+    vector[nsubjs] deltauhat;
+    
+    deltachat[i] <- deltahat[i,1];
+    deltarhat[i] <- deltahat[i,2];
+    deltauhat[i] <- deltahat[i,3];
+    
+    // Probitize Parameters c, r, and u 
+    c[i] <- Phi(muchat + deltachat[i]);
+    r[i] <- Phi(murhat + deltarhat[i]);
+    u[i] <- Phi(muuhat + deltauhat[i]);
+    
+    // MPT Category Probabilities for Word Pairs
+    theta[i,1] <- c[i] * r[i];
+    theta[i,2] <- (1 - c[i]) * (u[i]) ^ 2;
+    theta[i,3] <- (1 - c[i]) * 2 * u[i] * (1 - u[i]);
+    theta[i,4] <- c[i] * (1 - r[i]) + (1 - c[i]) * (1 - u[i]) ^ 2;
+  }
+}
+model {
+  // Priors
+  muchat ~ normal(0, 1);
+  murhat ~ normal(0, 1);
+  muuhat ~ normal(0, 1);
+  
+  tau ~ normal(0, 1); // to deal with divergent transitions, use constrained half-normal instead of Cauchy here.
+  Omega ~ lkj_corr(4);
+
+  deltahat ~ multi_normal(mudeltahat, quad_form_diag(Omega, tau));
+
+  // Data
+  for (i in 1:nsubjs)
+    k[i] ~ multinomial(theta[i]);
+}
+generated quantities {
+  real<lower=0,upper=1> muc;
+  real<lower=0,upper=1> mur;
+  real<lower=0,upper=1> muu;
+
+  // Post-Processing Means, Standard Deviations, Correlations
+  muc <- Phi(muchat);
+  mur <- Phi(murhat);
+  muu <- Phi(muuhat);
+}"
+
+### Riefer et al (2002) data:
+load("dataMPT.Rdata")
+
+nparams <- 3			# Number of free parameters per participant: c_i, r_i, u_i 
+
+myinits <- list(
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3),
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       tau = runif(3)),
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3), 
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       tau = runif(3)),
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3), 
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       tau = runif(3)))
+
+# Parameters to be monitored
+parameters <- c("muc", "mur", "muu", "tau", "Omega", "lp__")  
+
+# Run higher iterations for better estimate
+myiterations <- 2500 
+mywarmup <- 500
+
+k <- response_1
+nsubjs <- nrow(k)    	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+# The following command calls Stan with specific options.
+# For a detailed description type "?stan".
+samples_1 <- stan(model_code=model,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.95)  # increase adapt_delta to get rid of divergent transitions
+)
+
+samples_1
+traceplot(samples_1, pars = c("Omega", "tau", "lp__"))
+
+
+k <- response_2
+nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+samples_2 <- stan(fit=samples_1,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+)
+samples_2
+traceplot(samples_2, pars = c("Omega", "tau", "lp__"))
+
+k <- response_6
+nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+samples_6 <- stan(fit=samples_1,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+)
+samples_6
+traceplot(samples_6, pars = c("Omega", "tau", "lp__"))
+
+# Now the values for the monitored parameters are in the "samples" object, 
+# ready for inspection.
+muc1 <- extract(samples_1)$muc
+mur1 <- extract(samples_1)$mur
+muu1 <- extract(samples_1)$muu
+muc2 <- extract(samples_2)$muc
+mur2 <- extract(samples_2)$mur
+muu2 <- extract(samples_2)$muu
+muc6 <- extract(samples_6)$muc
+mur6 <- extract(samples_6)$mur
+muu6 <- extract(samples_6)$muu
+
+rhocr1 <- extract(samples_1)$Omega[, 1, 2]
+rhocu1 <- extract(samples_1)$Omega[, 1, 3]
+rhoru1 <- extract(samples_1)$Omega[, 2, 3]
+rhocr2 <- extract(samples_2)$Omega[, 1, 2]
+rhocu2 <- extract(samples_2)$Omega[, 1, 3]
+rhoru2 <- extract(samples_2)$Omega[, 2, 3]
+rhocr6 <- extract(samples_6)$Omega[, 1, 2]
+rhocu6 <- extract(samples_6)$Omega[, 1, 3]
+rhoru6 <- extract(samples_6)$Omega[, 2, 3]
+
+#### Plots posteriors of the group--level c, r, and u parameters
+windows(10, 5)
+layout(matrix(1:3, 1, 3, byrow=TRUE))
+par(cex=1.1, mar=c(2, 2, 1, 1), mgp=c(.8, .1, 0))
+
+plot(density(muc6), xlim=c(0, 1), ylim=c(0, 7), lty="dotted",
+     ylab="Probability Density", xlab=expression(mu[c]), main="", 
+     yaxt="n", xaxt="n")
+lines(density(muc2), lty="dashed")
+lines(density(muc1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+
+plot(density(mur6), xlim=c(0, 1), ylim=c(0, 15), lty="dotted", ylab="",
+     xlab=expression(mu[r]), yaxt="n", xaxt="n", main="")
+lines(density(mur2), lty="dashed")
+lines(density(mur1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+legend(0, 15.5, c("Trial 1", "Trial 2", "Trial 6"), lty = c(1, 2, 3), 
+       col=c("black"), text.col = "black", bty = "n")
+
+plot(density(muu6), xlim=c(0, 1), ylim=c(0, 9), lty="dotted", ylab="",
+     xlab=expression(mu[u]), yaxt="n", xaxt="n", main="")
+lines(density(muu2), lty="dashed")
+lines(density(muu1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+
+#### Plots posteriors for the correlations
+windows(10, 5)
+layout(matrix(1:3, 1, 3, byrow=TRUE))
+par(cex=1.1, mar=c(2, 2, 1, 1), mgp=c(.8, .1, 0))
+
+plot(density(rhocr6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted",
+     ylab="Probability Density", xlab=expression(italic(rho[cr])), main="", 
+     yaxt="n", xaxt="n")
+lines(density(rhocr2), lty="dashed")
+lines(density(rhocr1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+
+plot(density(rhocu6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted", ylab="",
+     xlab=expression(italic(rho[cu])), yaxt="n", xaxt="n", main="")
+lines(density(rhocu2), lty="dashed")
+lines(density(rhocu1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+legend(-1, 1.55, c("Trial 1", "Trial 2", "Trial 6"), lty = c(1, 2, 3), 
+       col=c("black"), text.col = "black", bty = "n")
+
+plot(density(rhoru6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted", ylab="",
+     xlab=expression(italic(rho[ru])), yaxt="n", xaxt="n", main="")
+lines(density(rhoru2), lty="dashed")
+lines(density(rhoru1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_3_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_3_Stan.R
@@ -122,11 +122,11 @@ samples_1 <- stan(model_code=model,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  control = list(adapt_delta = 0.95)  # increase adapt_delta to get rid of divergent transitions
+                  control = list(adapt_delta = 0.999, stepsize = 0.01, max_treedepth = 15)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 
 samples_1
-traceplot(samples_1, pars = c("Omega", "tau", "lp__"))
+traceplot(samples_1, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 
 k <- response_2
@@ -141,10 +141,10 @@ samples_2 <- stan(fit=samples_1,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+                  control = list(adapt_delta = 0.999, stepsize = 0.005, max_treedepth = 15)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 samples_2
-traceplot(samples_2, pars = c("Omega", "tau", "lp__"))
+traceplot(samples_2, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 k <- response_6
 nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
@@ -158,10 +158,10 @@ samples_6 <- stan(fit=samples_1,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+                  control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 15)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 samples_6
-traceplot(samples_6, pars = c("Omega", "tau", "lp__"))
+traceplot(samples_6, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 # Now the values for the monitored parameters are in the "samples" object, 
 # ready for inspection.

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_3_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_3_Stan.R
@@ -37,10 +37,11 @@ transformed parameters {
   vector<lower=0,upper=1>[nsubjs] r;
   vector<lower=0,upper=1>[nsubjs] u;
     
+  vector[nsubjs] deltachat;
+  vector[nsubjs] deltarhat;
+  vector[nsubjs] deltauhat;
+  
   for (i in 1:nsubjs) {
-    vector[nsubjs] deltachat;
-    vector[nsubjs] deltarhat;
-    vector[nsubjs] deltauhat;
     
     deltachat[i] <- deltahat[i,1];
     deltarhat[i] <- deltahat[i,2];

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_4_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_4_Stan.R
@@ -1,0 +1,240 @@
+# clears workspace: 
+rm(list=ls()) 
+
+library(rstan)
+rstan_options(auto_write = TRUE)
+options(mc.cores = parallel::detectCores())
+
+# model without parameter expansion
+# model with 2. coding section 6.12
+model <- "
+// Multinomial Processing Tree with Latent Traits
+data { 
+  int<lower=1> nsubjs; 
+  int<lower=1> nparams; 
+  int<lower=0,upper=20> k[nsubjs,4];
+}
+transformed data {
+  vector[3] mudeltahat;
+  
+  mudeltahat[1] <- 0;
+  mudeltahat[2] <- 0;
+  mudeltahat[3] <- 0;
+}
+parameters {
+  vector[nparams] deltahat[nsubjs]; 
+  
+  cholesky_factor_corr[nparams] L_Omega; 
+  vector<lower=0>[nparams] sigma; 
+
+  real muchat;
+  real murhat;
+  real muuhat;
+} 
+transformed parameters {
+  simplex[4] theta[nsubjs];
+  vector<lower=0,upper=1>[nsubjs] c;
+  vector<lower=0,upper=1>[nsubjs] r;
+  vector<lower=0,upper=1>[nsubjs] u;
+    
+  for (i in 1:nsubjs) {
+    vector[nsubjs] deltachat;
+    vector[nsubjs] deltarhat;
+    vector[nsubjs] deltauhat;
+    
+    deltachat[i] <- deltahat[i,1];
+    deltarhat[i] <- deltahat[i,2];
+    deltauhat[i] <- deltahat[i,3];
+    
+    // Probitize Parameters c, r, and u 
+    c[i] <- Phi(muchat + deltachat[i]);
+    r[i] <- Phi(murhat + deltarhat[i]);
+    u[i] <- Phi(muuhat + deltauhat[i]);
+    
+    // MPT Category Probabilities for Word Pairs
+    theta[i,1] <- c[i] * r[i];
+    theta[i,2] <- (1 - c[i]) * (u[i]) ^ 2;
+    theta[i,3] <- (1 - c[i]) * 2 * u[i] * (1 - u[i]);
+    theta[i,4] <- c[i] * (1 - r[i]) + (1 - c[i]) * (1 - u[i]) ^ 2;
+  }
+}
+model {
+  // Priors
+  muchat ~ normal(0, 1);
+  murhat ~ normal(0, 1);
+  muuhat ~ normal(0, 1);
+  
+  L_Omega ~ lkj_corr_cholesky(4); 
+  sigma ~ normal(0, 1); 
+  deltahat ~ multi_normal_cholesky(mudeltahat, diag_pre_multiply(sigma, L_Omega)); 
+
+  // Data
+  for (i in 1:nsubjs)
+    k[i] ~ multinomial(theta[i]);
+}
+generated quantities {
+  real<lower=0,upper=1> muc;
+  real<lower=0,upper=1> mur;
+  real<lower=0,upper=1> muu;
+  corr_matrix[nparams] Omega;
+
+  // Post-Processing Means, Standard Deviations, Correlations
+  muc <- Phi(muchat);
+  mur <- Phi(murhat);
+  muu <- Phi(muuhat);
+  
+  Omega <- L_Omega * L_Omega';
+}"
+
+### Riefer et al (2002) data:
+load("dataMPT.Rdata")
+
+nparams <- 3			# Number of free parameters per participant: c_i, r_i, u_i 
+
+myinits <- list(
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3),
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       sigma = runif(3)),
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3), 
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       sigma = runif(3)),
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3), 
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       sigma = runif(3)))
+
+# Parameters to be monitored
+parameters <- c("muc", "mur", "muu", "sigma", "Omega", "lp__")  
+
+# Run higher iterations for better estimate
+myiterations <- 2500 
+mywarmup <- 500
+
+k <- response_1
+nsubjs <- nrow(k)    	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+# The following command calls Stan with specific options.
+# For a detailed description type "?stan".
+samples_1 <- stan(model_code=model,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.95)  # increase adapt_delta to get rid of divergent transitions
+)
+
+samples_1
+traceplot(samples_1, pars = c("Omega", "sigma", "lp__"))
+
+
+k <- response_2
+nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+samples_2 <- stan(fit=samples_1,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+)
+samples_2
+traceplot(samples_2, pars = c("Omega", "sigma", "lp__"))
+
+k <- response_6
+nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+samples_6 <- stan(fit=samples_1,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+)
+samples_6
+traceplot(samples_6, pars = c("Omega", "sigma", "lp__"))
+
+# Now the values for the monitored parameters are in the "samples" object, 
+# ready for inspection.
+muc1 <- extract(samples_1)$muc
+mur1 <- extract(samples_1)$mur
+muu1 <- extract(samples_1)$muu
+muc2 <- extract(samples_2)$muc
+mur2 <- extract(samples_2)$mur
+muu2 <- extract(samples_2)$muu
+muc6 <- extract(samples_6)$muc
+mur6 <- extract(samples_6)$mur
+muu6 <- extract(samples_6)$muu
+
+rhocr1 <- extract(samples_1)$Omega[, 1, 2]
+rhocu1 <- extract(samples_1)$Omega[, 1, 3]
+rhoru1 <- extract(samples_1)$Omega[, 2, 3]
+rhocr2 <- extract(samples_2)$Omega[, 1, 2]
+rhocu2 <- extract(samples_2)$Omega[, 1, 3]
+rhoru2 <- extract(samples_2)$Omega[, 2, 3]
+rhocr6 <- extract(samples_6)$Omega[, 1, 2]
+rhocu6 <- extract(samples_6)$Omega[, 1, 3]
+rhoru6 <- extract(samples_6)$Omega[, 2, 3]
+
+#### Plots posteriors of the group--level c, r, and u parameters
+windows(10, 5)
+layout(matrix(1:3, 1, 3, byrow=TRUE))
+par(cex=1.1, mar=c(2, 2, 1, 1), mgp=c(.8, .1, 0))
+
+plot(density(muc6), xlim=c(0, 1), ylim=c(0, 7), lty="dotted",
+     ylab="Probability Density", xlab=expression(mu[c]), main="", 
+     yaxt="n", xaxt="n")
+lines(density(muc2), lty="dashed")
+lines(density(muc1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+
+plot(density(mur6), xlim=c(0, 1), ylim=c(0, 15), lty="dotted", ylab="",
+     xlab=expression(mu[r]), yaxt="n", xaxt="n", main="")
+lines(density(mur2), lty="dashed")
+lines(density(mur1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+legend(0, 15.5, c("Trial 1", "Trial 2", "Trial 6"), lty = c(1, 2, 3), 
+       col=c("black"), text.col = "black", bty = "n")
+
+plot(density(muu6), xlim=c(0, 1), ylim=c(0, 9), lty="dotted", ylab="",
+     xlab=expression(mu[u]), yaxt="n", xaxt="n", main="")
+lines(density(muu2), lty="dashed")
+lines(density(muu1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+
+#### Plots posteriors for the correlations
+windows(10, 5)
+layout(matrix(1:3, 1, 3, byrow=TRUE))
+par(cex=1.1, mar=c(2, 2, 1, 1), mgp=c(.8, .1, 0))
+
+plot(density(rhocr6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted",
+     ylab="Probability Density", xlab=expression(italic(rho[cr])), main="", 
+     yaxt="n", xaxt="n")
+lines(density(rhocr2), lty="dashed")
+lines(density(rhocr1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+
+plot(density(rhocu6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted", ylab="",
+     xlab=expression(italic(rho[cu])), yaxt="n", xaxt="n", main="")
+lines(density(rhocu2), lty="dashed")
+lines(density(rhocu1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+legend(-1, 1.55, c("Trial 1", "Trial 2", "Trial 6"), lty = c(1, 2, 3), 
+       col=c("black"), text.col = "black", bty = "n")
+
+plot(density(rhoru6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted", ylab="",
+     xlab=expression(italic(rho[ru])), yaxt="n", xaxt="n", main="")
+lines(density(rhoru2), lty="dashed")
+lines(density(rhoru1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_4_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_4_Stan.R
@@ -124,11 +124,11 @@ samples_1 <- stan(model_code=model,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  control = list(adapt_delta = 0.95)  # increase adapt_delta to get rid of divergent transitions
+                  control = list(adapt_delta = 0.995, stepsize = 0.01, max_treedepth = 15)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 
 samples_1
-traceplot(samples_1, pars = c("Omega", "sigma", "lp__"))
+traceplot(samples_1, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 
 k <- response_2
@@ -143,10 +143,10 @@ samples_2 <- stan(fit=samples_1,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+                  control = list(adapt_delta = 0.999, stepsize = 0.001, max_treedepth = 15)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 samples_2
-traceplot(samples_2, pars = c("Omega", "sigma", "lp__"))
+traceplot(samples_2, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 k <- response_6
 nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
@@ -160,10 +160,10 @@ samples_6 <- stan(fit=samples_1,
                   chains=3, 
                   thin=1,
                   warmup=mywarmup,  # Stands for burn-in; Default = iter/2
-                  control = list(adapt_delta = 0.95) # increase adapt_delta to get rid of divergent transitions
+                  control = list(adapt_delta = 0.995, stepsize = 0.01, max_treedepth = 15)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 samples_6
-traceplot(samples_6, pars = c("Omega", "sigma", "lp__"))
+traceplot(samples_6, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 # Now the values for the monitored parameters are in the "samples" object, 
 # ready for inspection.

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_4_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_4_Stan.R
@@ -36,11 +36,12 @@ transformed parameters {
   vector<lower=0,upper=1>[nsubjs] c;
   vector<lower=0,upper=1>[nsubjs] r;
   vector<lower=0,upper=1>[nsubjs] u;
-    
+  
+  vector[nsubjs] deltachat;
+  vector[nsubjs] deltarhat;
+  vector[nsubjs] deltauhat;
+
   for (i in 1:nsubjs) {
-    vector[nsubjs] deltachat;
-    vector[nsubjs] deltarhat;
-    vector[nsubjs] deltauhat;
     
     deltachat[i] <- deltahat[i,1];
     deltarhat[i] <- deltahat[i,2];

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
@@ -6,7 +6,7 @@ rstan_options(auto_write = TRUE)
 options(mc.cores = parallel::detectCores())
 
 # model without parameter expansion
-# model with 3. coding section 6.12
+# model with 3. coding section 6.12 (non-centered parameterization)
 model <- "
 // Multinomial Processing Tree with Latent Traits
 data { 
@@ -32,11 +32,11 @@ transformed parameters {
   vector<lower=0,upper=1>[nsubjs] u;
   
   matrix[nsubjs,nparams] deltahat; 
-  deltahat <- (diag_pre_multiply(sigma, L_Omega) * deltahat_tilde)'; 
-  
   vector[nsubjs] deltachat;
   vector[nsubjs] deltarhat;
   vector[nsubjs] deltauhat;
+
+  deltahat <- (diag_pre_multiply(sigma, L_Omega) * deltahat_tilde)'; 
 
   for (i in 1:nsubjs) {
     
@@ -120,11 +120,12 @@ samples_1 <- stan(model_code=model,
                   iter=myiterations, 
                   chains=3, 
                   thin=1,
-                  warmup=mywarmup  # Stands for burn-in; Default = iter/2
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.9)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 
 samples_1
-traceplot(samples_1, pars = c("Omega", "sigma", "lp__"))
+traceplot(samples_1, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 
 k <- response_2
@@ -138,10 +139,11 @@ samples_2 <- stan(fit=samples_1,
                   iter=myiterations, 
                   chains=3, 
                   thin=1,
-                  warmup=mywarmup  # Stands for burn-in; Default = iter/2
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.9)  # increase adapt_delta/decrease stepsize to get rid of divergent transitions
 )
 samples_2
-traceplot(samples_2, pars = c("Omega", "sigma", "lp__"))
+traceplot(samples_2, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 k <- response_6
 nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
@@ -154,10 +156,11 @@ samples_6 <- stan(fit=samples_1,
                   iter=myiterations, 
                   chains=3, 
                   thin=1,
-                  warmup=mywarmup  # Stands for burn-in; Default = iter/2
+                  warmup=mywarmup,  # Stands for burn-in; Default = iter/2
+                  control = list(adapt_delta = 0.9)  # increase adapt_delta/decrease stepsize to get rid of divergent transition
 )
 samples_6
-traceplot(samples_6, pars = c("Omega", "sigma", "lp__"))
+traceplot(samples_6, pars = c("muc", "mur", "muu", "Omega", "sigma", "lp__"))
 
 # Now the values for the monitored parameters are in the "samples" object, 
 # ready for inspection.

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
@@ -1,0 +1,234 @@
+# clears workspace: 
+rm(list=ls()) 
+
+library(rstan)
+rstan_options(auto_write = TRUE)
+options(mc.cores = parallel::detectCores())
+
+# model without parameter expansion
+# model with 3. coding section 6.12
+model <- "
+// Multinomial Processing Tree with Latent Traits
+data { 
+  int<lower=1> nsubjs; 
+  int<lower=1> nparams; 
+  int<lower=0,upper=20> k[nsubjs,4];
+}
+
+parameters {
+  matrix[nparams,nsubjs] deltahat_tilde; 
+  
+  cholesky_factor_corr[nparams] L_Omega; 
+  vector<lower=0>[nparams] sigma; 
+
+  real muchat;
+  real murhat;
+  real muuhat;
+} 
+transformed parameters {
+  simplex[4] theta[nsubjs];
+  vector<lower=0,upper=1>[nsubjs] c;
+  vector<lower=0,upper=1>[nsubjs] r;
+  vector<lower=0,upper=1>[nsubjs] u;
+  
+  matrix[nsubjs,nparams] deltahat; 
+  deltahat <- (diag_pre_multiply(sigma, L_Omega) * deltahat_tilde)'; 
+    
+  for (i in 1:nsubjs) {
+    vector[nsubjs] deltachat;
+    vector[nsubjs] deltarhat;
+    vector[nsubjs] deltauhat;
+    
+    deltachat[i] <- deltahat[i,1];
+    deltarhat[i] <- deltahat[i,2];
+    deltauhat[i] <- deltahat[i,3];
+    
+    // Probitize Parameters c, r, and u 
+    c[i] <- Phi(muchat + deltachat[i]);
+    r[i] <- Phi(murhat + deltarhat[i]);
+    u[i] <- Phi(muuhat + deltauhat[i]);
+    
+    // MPT Category Probabilities for Word Pairs
+    theta[i,1] <- c[i] * r[i];
+    theta[i,2] <- (1 - c[i]) * (u[i]) ^ 2;
+    theta[i,3] <- (1 - c[i]) * 2 * u[i] * (1 - u[i]);
+    theta[i,4] <- c[i] * (1 - r[i]) + (1 - c[i]) * (1 - u[i]) ^ 2;
+  }
+}
+model {
+  // Priors
+  muchat ~ normal(0, 1);
+  murhat ~ normal(0, 1);
+  muuhat ~ normal(0, 1);
+  
+  L_Omega ~ lkj_corr_cholesky(4); 
+  sigma ~ cauchy(0, 2.5); 
+  to_vector(deltahat_tilde) ~ normal(0, 1); 
+
+  // Data
+  for (i in 1:nsubjs)
+    k[i] ~ multinomial(theta[i]);
+}
+generated quantities {
+  real<lower=0,upper=1> muc;
+  real<lower=0,upper=1> mur;
+  real<lower=0,upper=1> muu;
+  corr_matrix[nparams] Omega;
+
+  // Post-Processing Means, Standard Deviations, Correlations
+  muc <- Phi(muchat);
+  mur <- Phi(murhat);
+  muu <- Phi(muuhat);
+  
+  Omega <- L_Omega * L_Omega';
+}"
+
+### Riefer et al (2002) data:
+load("dataMPT.Rdata")
+
+nparams <- 3			# Number of free parameters per participant: c_i, r_i, u_i 
+
+myinits <- list(
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3),
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       sigma = runif(3)),
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3), 
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       sigma = runif(3)),
+  list(deltahat=matrix(rnorm(21 * 3), 21, 3), Omega=diag(3), 
+       muchat=rnorm(1), murhat=rnorm(1), muuhat=rnorm(1),
+       sigma = runif(3)))
+
+# Parameters to be monitored
+parameters <- c("muc", "mur", "muu", "sigma", "Omega", "L_Omega", "lp__")  
+
+# Run higher iterations for better estimate
+myiterations <- 2500 
+mywarmup <- 500
+
+k <- response_1
+nsubjs <- nrow(k)    	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+# The following command calls Stan with specific options.
+# For a detailed description type "?stan".
+samples_1 <- stan(model_code=model,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup  # Stands for burn-in; Default = iter/2
+)
+
+samples_1
+traceplot(samples_1, pars = c("Omega", "sigma", "lp__"))
+
+
+k <- response_2
+nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+samples_2 <- stan(fit=samples_1,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup  # Stands for burn-in; Default = iter/2
+)
+samples_2
+traceplot(samples_2, pars = c("Omega", "sigma", "lp__"))
+
+k <- response_6
+nsubjs <- nrow(k) 	 	# Number of word pairs per participant	
+data <- list(k=k, nparams=nparams, nsubjs=nsubjs) # To be passed on to Stan
+
+samples_6 <- stan(fit=samples_1,   
+                  data=data, 
+                  init=myinits,  # If not specified, gives random inits
+                  pars=parameters,
+                  iter=myiterations, 
+                  chains=3, 
+                  thin=1,
+                  warmup=mywarmup  # Stands for burn-in; Default = iter/2
+)
+samples_6
+traceplot(samples_6, pars = c("Omega", "sigma", "lp__"))
+
+# Now the values for the monitored parameters are in the "samples" object, 
+# ready for inspection.
+muc1 <- extract(samples_1)$muc
+mur1 <- extract(samples_1)$mur
+muu1 <- extract(samples_1)$muu
+muc2 <- extract(samples_2)$muc
+mur2 <- extract(samples_2)$mur
+muu2 <- extract(samples_2)$muu
+muc6 <- extract(samples_6)$muc
+mur6 <- extract(samples_6)$mur
+muu6 <- extract(samples_6)$muu
+
+rhocr1 <- extract(samples_1)$Omega[, 1, 2]
+rhocu1 <- extract(samples_1)$Omega[, 1, 3]
+rhoru1 <- extract(samples_1)$Omega[, 2, 3]
+rhocr2 <- extract(samples_2)$Omega[, 1, 2]
+rhocu2 <- extract(samples_2)$Omega[, 1, 3]
+rhoru2 <- extract(samples_2)$Omega[, 2, 3]
+rhocr6 <- extract(samples_6)$Omega[, 1, 2]
+rhocu6 <- extract(samples_6)$Omega[, 1, 3]
+rhoru6 <- extract(samples_6)$Omega[, 2, 3]
+
+#### Plots posteriors of the group--level c, r, and u parameters
+windows(10, 5)
+layout(matrix(1:3, 1, 3, byrow=TRUE))
+par(cex=1.1, mar=c(2, 2, 1, 1), mgp=c(.8, .1, 0))
+
+plot(density(muc6), xlim=c(0, 1), ylim=c(0, 7), lty="dotted",
+     ylab="Probability Density", xlab=expression(mu[c]), main="", 
+     yaxt="n", xaxt="n")
+lines(density(muc2), lty="dashed")
+lines(density(muc1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+
+plot(density(mur6), xlim=c(0, 1), ylim=c(0, 15), lty="dotted", ylab="",
+     xlab=expression(mu[r]), yaxt="n", xaxt="n", main="")
+lines(density(mur2), lty="dashed")
+lines(density(mur1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+legend(0, 15.5, c("Trial 1", "Trial 2", "Trial 6"), lty = c(1, 2, 3), 
+       col=c("black"), text.col = "black", bty = "n")
+
+plot(density(muu6), xlim=c(0, 1), ylim=c(0, 9), lty="dotted", ylab="",
+     xlab=expression(mu[u]), yaxt="n", xaxt="n", main="")
+lines(density(muu2), lty="dashed")
+lines(density(muu1))
+axis(1, seq(0, 1, by=.2), tick=FALSE)
+
+#### Plots posteriors for the correlations
+windows(10, 5)
+layout(matrix(1:3, 1, 3, byrow=TRUE))
+par(cex=1.1, mar=c(2, 2, 1, 1), mgp=c(.8, .1, 0))
+
+plot(density(rhocr6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted",
+     ylab="Probability Density", xlab=expression(italic(rho[cr])), main="", 
+     yaxt="n", xaxt="n")
+lines(density(rhocr2), lty="dashed")
+lines(density(rhocr1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+
+plot(density(rhocu6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted", ylab="",
+     xlab=expression(italic(rho[cu])), yaxt="n", xaxt="n", main="")
+lines(density(rhocu2), lty="dashed")
+lines(density(rhocu1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+legend(-1, 1.55, c("Trial 1", "Trial 2", "Trial 6"), lty = c(1, 2, 3), 
+       col=c("black"), text.col = "black", bty = "n")
+
+plot(density(rhoru6), xlim=c(-1, 1), ylim=c(0, 1.5), lty="dotted", ylab="",
+     xlab=expression(italic(rho[ru])), yaxt="n", xaxt="n", main="")
+lines(density(rhoru2), lty="dashed")
+lines(density(rhoru1))
+axis(1, seq(-1, 1, by=.5), tick=FALSE)
+

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
@@ -33,11 +33,12 @@ transformed parameters {
   
   matrix[nsubjs,nparams] deltahat; 
   deltahat <- (diag_pre_multiply(sigma, L_Omega) * deltahat_tilde)'; 
-    
+  
+  vector[nsubjs] deltachat;
+  vector[nsubjs] deltarhat;
+  vector[nsubjs] deltauhat;
+
   for (i in 1:nsubjs) {
-    vector[nsubjs] deltachat;
-    vector[nsubjs] deltarhat;
-    vector[nsubjs] deltauhat;
     
     deltachat[i] <- deltahat[i,1];
     deltarhat[i] <- deltahat[i,2];

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/README
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/README
@@ -5,10 +5,12 @@ models should be programmed in Stan using HMC. Some features of the original
 hierarchical implementation were specifically added to allow for a better 
 convergence using Gibbs sampling such as implemented in JAGS or Bugs. These 
 features do not help the model for the HMC sampler used by Stan and in fact, the 
-model shows convergence issues with divergent transitions that are difficult to
-deal with. 
+model shows convergence issues with divergent transitions that can only be 
+handeled by relatively strongly changing the stan samplers default settings. 
+And even when removing the divergent transitions the final samples still show
+problematic signs.
 
-The new implementations avoid those features. Specifically, these 
+The new implementations avoid the Gibbs specific features. Specifically, these 
 implementations do not use the Wishart as prior for the correlation matrix and 
 do not use the parameter expansion, but can neverthless handle the divergent 
 transitions. We include three implementations which follow the three 

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/README
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/README
@@ -1,0 +1,44 @@
+In addition to the two implementations given in the Lee and Wagenmakers book, 
+this folder contains three further implementationso of the hierarchical model.
+These further implementations are more in line with the suggested way such 
+models should be programmed in Stan using HMC. Some features of the original 
+hierarchical implementation were specifically added to allow for a better 
+convergence using Gibbs sampling such as implemented in JAGS or Bugs. These 
+features do not help the model for the HMC sampler used by Stan and in fact, the 
+model shows convergence issues with divergent transitions that are difficult to
+deal with. 
+
+The new implementations avoid those features. Specifically, these 
+implementations do not use the Wishart as prior for the correlation matrix and 
+do not use the parameter expansion, but can neverthless handle the divergent 
+transitions. We include three implementations which follow the three 
+recommendations given in the Stan manual (section 6.12. "Multivariate Priors for 
+Hierarchical Models") for the Multivariate Regression Example of Gelman and 
+Hill. All three of these have no parameter expansion parameters (xichat, ...). 
+The other changes are: 
+
+1. MPT_3_Stan.R:
+Simply replaces the Wishart prior for the correlation with a correlation matrix 
+Omega with LKJ prior and scaling vector tau. 
+This model still shows some numerical problems and a few divergent transitions, 
+even after constraining the prior for the scaling parameter tau to a half-normal 
+with mean 0 and SD of 1 and increasing adapt_delta. Also, there are quite some 
+correlation matrices that are not positive definite during estimation.
+
+2. MPT_4_Stan.R:
+Further replace the correlation matrix Omega with its Cholesky factor L_Omega 
+and corresponding prior. Likewise, tau will be replaced by corresponding scaling
+parameter sigma. Whereas this noticably increases the speed of optimization it 
+does not really remove all the remaining numerical problems. We still have very
+few divergent transitions. But the numerical problems with the correlation 
+matrices are gone.
+
+3. MPT_4_Stan.R:
+This contains a further reparametrization of the multivariate normal 
+distribution using a univariate distribtuion and basically solves the remaining 
+issues. This reparametrization is extensively discussed in section 21.2. of the 
+Stan manual. But it also is the same as given in section 6.12. 
+
+
+For further details see the correspondoing thread on the Stan mailing list:
+https://groups.google.com/forum/#!topic/stan-users/ZTiu_ij_bC8

--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/README
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/README
@@ -1,45 +1,48 @@
 In addition to the two implementations given in the Lee and Wagenmakers book, 
 this folder contains three further implementationso of the hierarchical model.
 These further implementations are more in line with the suggested way such 
-models should be programmed in Stan using HMC. Some features of the original 
-hierarchical implementation were specifically added to allow for a better 
-convergence using Gibbs sampling such as implemented in JAGS or Bugs. These 
-features do not help the model for the HMC sampler used by Stan and in fact, the 
-model shows convergence issues with divergent transitions that can only be 
-handeled by relatively strongly changing the stan samplers default settings. 
-And even when removing the divergent transitions the final samples still show
-problematic signs.
+models should be programmed in Stan. Some features of the original hierarchical 
+implementation were specifically added to allow for a better convergence using 
+Gibbs sampling such as implemented in JAGS or Bugs. These features do not help 
+the convergence using the NUTS/HMC sampler used by Stan and in fact, the 
+original model shows convergence issues with divergent transitions that can only
+be handeled by relatively strongly changing the Stan samplers' default settings.
 
 The new implementations avoid the Gibbs specific features. Specifically, these 
 implementations do not use the Wishart as prior for the correlation matrix and 
-do not use the parameter expansion, but can neverthless handle the divergent 
-transitions. We include three implementations which follow the three 
-recommendations given in the Stan manual (section 6.12. "Multivariate Priors for 
-Hierarchical Models") for the Multivariate Regression Example of Gelman and 
-Hill. All three of these have no parameter expansion parameters (xichat, ...). 
-The other changes are: 
+do not use the parameter expansion. 
+We include three implementations which follow the three recommendations given in
+the Stan manual (section 6.12. "Multivariate Priors for Hierarchical Models") 
+for the Multivariate Regression Example of Gelman and Hill. All three of these 
+have no parameter expansion parameters (xichat, ...). The other changes are: 
 
 1. MPT_3_Stan.R:
 Simply replaces the Wishart prior for the correlation with a correlation matrix 
 Omega with LKJ prior and scaling vector tau. 
-This model still shows some numerical problems and a few divergent transitions, 
-even after constraining the prior for the scaling parameter tau to a half-normal 
-with mean 0 and SD of 1 and increasing adapt_delta. Also, there are quite some 
-correlation matrices that are not positive definite during estimation.
+This model still requires some tweaking of the sampler setting to run without 
+any divergent transitions or other numerical problems. There also can occur some
+correlation matrices during estimation that are not positive definite. However, 
+it increases fitting speed dramatically. Final fits still does not look 
+completely well behaved (when looking at the traceplots).
 
 2. MPT_4_Stan.R:
 Further replace the correlation matrix Omega with its Cholesky factor L_Omega 
 and corresponding prior. Likewise, tau will be replaced by corresponding scaling
-parameter sigma. Whereas this noticably increases the speed of optimization it 
-does not really remove all the remaining numerical problems. We still have very
-few divergent transitions. But the numerical problems with the correlation 
-matrices are gone.
+parameter sigma. Whereas this again noticably increases the speed of 
+optimization it does still requires tweaking of the sampler setting to converge
+without problems and the final fit is not completely well behaved.
 
 3. MPT_4_Stan.R:
 This contains a further reparametrization of the multivariate normal 
-distribution using a univariate distribtuion and basically solves the remaining 
-issues. This reparametrization is extensively discussed in section 21.2. of the 
-Stan manual. But it also is the same as given in section 6.12. 
+distribution using a univariate normal distribtuion and basically solves the 
+remaining issues. Specifically, this uses a non-centered parametrization of the 
+multivariate normal (also known as the 'Matt trick' on the Stan mailing list). 
+It further dramatically increases the speed and at the same time dramatically
+increases the number of effective samples using the same number of samples. It 
+also requires only minimal tweaking of the sampler setting to remove the very 
+few remaining issues. Finally, the traceplot show no problem whatsoever.
+The non-centered parameterization is extensively discussed in section 21.2. of 
+the Stan manual. But it also is the same as given in section 6.12. 
 
 
 For further details see the correspondoing thread on the Stan mailing list:


### PR DESCRIPTION
Following my question on the mailing list how to deal with the divergent transitions in one example model from the Lee and Wagenmakers book I have made the following changes:
- Tweaked the sampler settings to remove the divergent transitions in the original model (increased `adapt_delta` and `max_treedepth`, specified low `stepsize`).
- Added three new models which remove the Gibbs specific features in the example model (parameter expansion and Wishart prior for Covariances) and implement different reparameterizations:
   1. LKJ correlation instead of Wishart
   2. Cholesky of LKJ
   3. non-centered parameterization instead of multivariate normal.
- I added a README to describe those additions.
- I added a few cosmetic changes (mainly `traceplots` for all examples).

The mailing list thread which started this pull request can be found here: https://groups.google.com/forum/#!topic/stan-users/ZTiu_ij_bC8

Cheers,
Henrik