### PR TITLE
Removing mu_a from example-models/ARM/Ch.13/radon_vary_si_chr.stan

### DIFF
--- a/ARM/Ch.13/radon_vary_si_chr.stan
+++ b/ARM/Ch.13/radon_vary_si_chr.stan
@@ -12,7 +12,6 @@ parameters {
   real<lower=0,upper=100> sigma_a1;
   real<lower=0,upper=100> sigma_a2;
   real<lower=0,upper=100> sigma_y;
-  real mu_a;
 }
 transformed parameters {
   vector[85] a1;


### PR DESCRIPTION
This may be overkill for an one-line change, but the pull request is to remove the parameter `mu_a` from example-models/ARM/Ch.13/radon_vary_si_chr.stan because it isn't used anywhere else in the code and affects convergence diagnostics.

