### PR TITLE
Fixes for issue 99, BPA examples

### DIFF
--- a/BPA/Ch.06/M0.stan
+++ b/BPA/Ch.06/M0.stan
@@ -46,7 +46,9 @@ model {
 }
 
 generated quantities {
-  int<lower=C> N;
+  int<lower=C, upper=M> N;
+  real omega_nd;  // prob present given never detected
+  omega_nd = (omega * (1 - p)^T) / (omega * (1 - p)^T + (1 - omega));
 
-  N = C + binomial_rng(M, omega * (1 - p)^T);
+  N = C + binomial_rng(M - C, omega_nd);
 }

--- a/BPA/Ch.06/Mb.stan
+++ b/BPA/Ch.06/Mb.stan
@@ -62,16 +62,13 @@ model {
 }
 
 generated quantities {
-  int<lower=0,upper=1> zero[M];
-  int<lower=C> N;
+  int<lower=C, upper=M> N;
   real trap_response;
+  real omega_nd;  // prob present given never detected
+  // animals never detected have not been detected before, so p.eff == p
+  omega_nd = (omega * (1 - p)^T) / (omega * (1 - p)^T + (1 - omega));
 
-  for (i in 1:M) {
-    real pr;
+  N = C + binomial_rng(M - C, omega_nd);
 
-    pr = prod(rep_vector(1.0, T) - p_eff[i]);
-    zero[i] = bernoulli_rng(omega * pr);
-  }
-  N = C + sum(zero);
   trap_response = c - p;
 }

--- a/BPA/Ch.06/Mh.stan
+++ b/BPA/Ch.06/Mh.stan
@@ -54,14 +54,17 @@ model {
 }
 
 generated quantities {
-  int<lower=0,upper=1> zero[M];
+  int<lower=0,upper=1> z[M];
   int<lower=C> N;
 
   for (i in 1:M) {
-    real pr;
-
-    pr = (1.0 - inv_logit(eps[i]))^T;
-    zero[i] = bernoulli_rng(omega * pr);
+    if(y[i] > 0) {  // animal was detected at least once
+      z[i] = 1;
+    } else {        // animal was never detected
+      real qT;
+      qT = (inv_logit(-eps[i]))^T;  // q^T where q = 1 - p; prob never detected given present
+      z[i] = bernoulli_rng(omega * qT / (omega * qT + (1 - omega)));
+    }
   }
-  N = C + sum(zero);
+  N = sum(z);
 }

--- a/BPA/Ch.06/Mt.stan
+++ b/BPA/Ch.06/Mt.stan
@@ -47,8 +47,10 @@ model {
 
 generated quantities {
   int<lower=C> N;
-  real pr;
-
+  real pr;        // prob never captured given present
+  real omega_nd;  // prob present given never captured; same for all animals
+  
   pr = prod(rep_vector(1.0, T) - p);
-  N = C + binomial_rng(M, omega * pr);
+  omega_nd = (omega * pr) / (omega * pr + (1 - omega));
+  N = C + binomial_rng(M - C, omega_nd);
 }

--- a/BPA/Ch.06/MtX.stan
+++ b/BPA/Ch.06/MtX.stan
@@ -70,15 +70,17 @@ model {
 }
 
 generated quantities {
-  int<lower=0,upper=1> zero[M];
+  int<lower=0,upper=1> z[M];
   int<lower=C> N;
-  real trap_response;
 
   for (i in 1:M) {
-    real pr;
-
-    pr = prod(rep_vector(1.0, T) - p[i]);
-    zero[i] = bernoulli_rng(omega * pr);
+    if(s[i] > 0) {  // species was detected at least once
+      z[i] = 1;
+    } else {        // species was never detected
+      real pr;      // prob never detected given present
+      pr = prod(rep_vector(1.0, T) - p[i]);
+      z[i] = bernoulli_rng(omega * pr / (omega * pr + (1 - omega)));
+    }
   }
-  N = C + sum(zero);
+  N = sum(z);
 }

--- a/BPA/Ch.06/Mtbh.stan
+++ b/BPA/Ch.06/Mtbh.stan
@@ -80,15 +80,17 @@ model {
 }
 
 generated quantities {
-  int<lower=0,upper=1> zero[M];
+  int<lower=0,upper=1> z[M];
   int<lower=C> N;
 
   for (i in 1:M) {
-    real pr;
-
-
-    pr = prod(rep_vector(1.0, T) - p[i]);
-    zero[i] = bernoulli_rng(omega * pr);
+    if(s[i] > 0) {  // animal was detected at least once
+      z[i] = 1;
+    } else {        // animal never detected
+      real pr;      // prob never detected given present
+      pr = prod(rep_vector(1.0, T) - p[i]);
+      z[i] = bernoulli_rng(omega * pr / (omega * pr + (1 - omega)));
+    }
   }
-  N = C + sum(zero);
+  N = sum(z);
 }

--- a/BPA/Ch.06/Mth.stan
+++ b/BPA/Ch.06/Mth.stan
@@ -67,14 +67,16 @@ model {
 }
 
 generated quantities {
-  int<lower=0,upper=1> zero[M];
+  int<lower=0,upper=1> z[M];
   int<lower=C> N;
 
   for (i in 1:M) {
-    real pr;
-
-    pr = prod(rep_vector(1.0, T) - p[i]);
-    zero[i] = bernoulli_rng(omega * pr);
+    if(s[i] > 0) {  // animal was detected at least once
+      z[i] = 1;
+    } else {        // animal was never detected
+      real pr;      // prob never detected given present
+      pr = prod(rep_vector(1.0, T) - p[i]);
+      z[i] = bernoulli_rng(omega * pr / (omega * pr + (1 - omega)));
+    }
   }
-  N = C + sum(zero);
-}
+  N = sum(z);}

--- a/BPA/Ch.07/cjs_mnl.stan
+++ b/BPA/Ch.07/cjs_mnl.stan
@@ -59,14 +59,14 @@ model {
 generated quantities {
   real fit;
   real fit_new;
-  matrix[n_occ_minus_1, n_occasions] E_org;
-  matrix[n_occ_minus_1, n_occasions] E_new;
-  vector[n_occasions] expmarr[n_occ_minus_1];
-  int<lower=0> marr_new[n_occ_minus_1, n_occasions];
+  matrix[n_occasions_minus_1, n_occasions] E_org;
+  matrix[n_occasions_minus_1, n_occasions] E_new;
+  vector[n_occasions] expmarr[n_occasions_minus_1];
+  int<lower=0> marr_new[n_occasions_minus_1, n_occasions];
 
   // Assess model fit using Freeman-Tukey statistic
   // Compute fit statistics for observed data
-  for (t in 1:n_occ_minus_1){
+  for (t in 1:n_occasions_minus_1){
     expmarr[t] = r[t] * pr[t];
     for (j in 1:n_occasions){
       E_org[t, j] = square((sqrt(marr[t][j]) - sqrt(expmarr[t][j])));
@@ -74,7 +74,7 @@ generated quantities {
   } //t
 
   // Generate replicate data and compute fit stats from them
-  for (t in 1:n_occ_minus_1) {
+  for (t in 1:n_occasions_minus_1) {
     marr_new[t] = multinomial_rng(pr[t], r[t]);
     for (j in 1:n_occasions) {
       E_new[t, j] = square((sqrt(marr_new[t][j]) - sqrt(expmarr[t][j])));

--- a/BPA/Ch.13/site-occ.stan
+++ b/BPA/Ch.13/site-occ.stan
@@ -7,7 +7,7 @@ data {
 }
 
 transformed data {
-  int<lower=0,upper=T> sum_y[R];  // Number of occupation for each site
+  int<lower=0,upper=T> sum_y[R];  // Number of detections for each site
   int<lower=0,upper=R> occ_obs;   // Number of observed occupied sites
 
   occ_obs = 0;
@@ -43,9 +43,9 @@ model {
 }
 
 generated quantities {
-  real<lower=occ_obs> occ_fs;
-
-  // Observed number of occupied sites
-  // + Number of sites occupied and not observed
-  occ_fs = occ_obs + binomial_rng(R, psi * (1 - p)^T);
+  int<lower=occ_obs, upper=R> occ_fs;
+  real psi_nd;  // prob occurred given not detected
+  
+  psi_nd = (psi * (1 - p)^T) / (psi * (1 - p)^T + (1 - psi));
+  occ_fs = occ_obs + binomial_rng(R - occ_obs, psi_nd);
 }


### PR DESCRIPTION
Changes to generated quantities in Stan models to use conditional (on
non-detection) values for psi or omega as discussed in Issue 99. Also
typo in Ch.07/chs_mnl.stan