### PR TITLE
Fix some notation and formatting.

### DIFF
--- a/knitr/car-iar-poisson/icar_stan.Rmd
+++ b/knitr/car-iar-poisson/icar_stan.Rmd
@@ -52,7 +52,7 @@ $\mathbf{\phi} = ({\phi}_1, \ldots, {\phi}_n)^T$.
 
 For CAR models, spatial relationship between the $n$ areal units
 are represented as an adjacency matrix $W$ with dimensions $n \times n$
-where entries $w_{i,j}$ and $w_{j,i}$ are positive when regions ${n_i}$ and ${n_j}$ are neighbors
+where entries $w_{i,j}$ and $w_{j,i}$ are positive when regions $i$ and $j$ are neighbors
 and zero otherwise.
 The _neighbor_ relationship $i \sim j$ is defined in terms of this matrix:
 the neighbors of region $i$ are those regions who have non-zero entries in row or column $i$.
@@ -92,9 +92,9 @@ where
 
 - $\alpha$ is between 0 and 1
 - $B$ is the $n \times n$ matrix weights matrix $W$ where entries $\{i,i\}$ are zero and the off-diagonal elements
-describe the spatial proximity of regions $n_i$ and $n_j$
+describe the spatial proximity of regions $i$ and $j$
 - $I$ is an $n \times n$ identity matrix
-- $D_{\tau} = \tau D$ where D is an $n \times n$ diagonal matrix
+- $D_{\tau} = \tau D$ where $D$ is an $n \times n$ diagonal matrix
 
 The construction of the spatial proximity matrix $B$ determines the class of CAR model structure.
 


### PR DESCRIPTION
Hi @mitzimorris!

Hope this finds you well.

I'm not entirely sure of my changes, which is why I checked "Allow edits from maintainers."

I understand that there are $n$ regions and we identify a region by $i$ (and, say, another region by $j$). So $i$ runs from $1, ..., n$.

But, apparently, there are also "$n$ different areal units of a region" (in a region? in each region?); then I would understand $n_i$ to be an areal unit of region $i$.

Does $n_i = 1, ..., n$? It would seem odd that this would be the same $n$ (number of regions vs. number of areal units per region).

Am I completely off? Please let me know!

I've also noticed that, starting at section "Adding an ICAR component to a Stan model," $n$ (which one?) seems to become $N$ while, earlier on, $N$ is used to denote the normal distribution.

Thank you,
Marianne