### PR TITLE
Minor performance improvement to MPT_5_Stan.R

### DIFF
--- a/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
+++ b/Bayesian_Cognitive_Modeling/CaseStudies/MPT/MPT_5_Stan.R
@@ -64,7 +64,7 @@ model {
   
   L_Omega ~ lkj_corr_cholesky(4); 
   sigma ~ cauchy(0, 2.5); 
-  to_vector(deltahat_tilde) ~ normal(0, 1); 
+  to_vector(deltahat_tilde) ~ std_normal(); 
 
   // Data
   for (i in 1:nsubjs)


### PR DESCRIPTION
According to the Stan functions reference std_normal() should be "much more efficient" than normal(0, 1) (https://mc-stan.org/docs/2_18/functions-reference/normal-distribution.html).