### PR TITLE
HMM fix

### DIFF
--- a/misc/hmm/hmm-analytic.stan
+++ b/misc/hmm/hmm-analytic.stan
@@ -10,21 +10,21 @@ data {
 transformed data {
   vector<lower=0>[K] alpha_post[K];
   vector<lower=0>[V] beta_post[K];
-  for (k in 1:K) 
-    alpha_post[k] <- alpha;
-  for (t in 2:T)
-    alpha_post[z[t-1],z[t]] <- alpha_post[z[t-1],z[t]] + 1;
   for (k in 1:K)
-    beta_post[k] <- beta;
+    alpha_post[k] = alpha;
+  for (t in 2:T)
+    alpha_post[z[t-1],z[t]] = alpha_post[z[t-1],z[t]] + 1;
+  for (k in 1:K)
+    beta_post[k] = beta;
   for (t in 1:T)
-    beta_post[z[t],w[t]] <- beta_post[z[t],w[t]] + 1;
+    beta_post[z[t],w[t]] = beta_post[z[t],w[t]] + 1;
 }
 parameters {
   simplex[K] theta[K];  // transit probs
   simplex[V] phi[K];    // emit probs
 }
 model {
-  for (k in 1:K) 
+  for (k in 1:K)
     theta[k] ~ dirichlet(alpha_post[k]);
   for (k in 1:K)
     phi[k] ~ dirichlet(beta_post[k]);

--- a/misc/hmm/hmm-semisup.stan
+++ b/misc/hmm/hmm-semisup.stan
@@ -28,15 +28,15 @@ model {
     real acc[K];
     real gamma[T_unsup,K];
     for (k in 1:K)
-      gamma[1,k] <- log(phi[k,u[1]]);
+      gamma[1,k] = log(phi[k,u[1]]);
     for (t in 2:T_unsup) {
       for (k in 1:K) {
         for (j in 1:K)
-          acc[j] <- gamma[t-1,j] + log(theta[j,k]) + log(phi[k,u[t]]);
-        gamma[t,k] <- log_sum_exp(acc);
+          acc[j] = gamma[t-1,j] + log(theta[j,k]) + log(phi[k,u[t]]);
+        gamma[t,k] = log_sum_exp(acc);
       }
     }
-    increment_log_prob(log_sum_exp(gamma[T_unsup]));
+    target += log_sum_exp(gamma[T_unsup]);
   }
 }
 generated quantities {
@@ -47,26 +47,26 @@ generated quantities {
     int back_ptr[T_unsup,K];
     real best_logp[T_unsup,K];
     for (k in 1:K)
-      best_logp[1,K] <- log(phi[k,u[1]]);
+      best_logp[1,K] = log(phi[k,u[1]]);
     for (t in 2:T_unsup) {
       for (k in 1:K) {
-        best_logp[t,k] <- negative_infinity();
+        best_logp[t,k] = negative_infinity();
         for (j in 1:K) {
           real logp;
-          logp <- best_logp[t-1,j] + log(theta[j,k]) + log(phi[k,u[t]]);
+          logp = best_logp[t-1,j] + log(theta[j,k]) + log(phi[k,u[t]]);
           if (logp > best_logp[t,k]) {
-            back_ptr[t,k] <- j;
-            best_logp[t,k] <- logp;
+            back_ptr[t,k] = j;
+            best_logp[t,k] = logp;
           }
         }
       }
     }
-    log_p_y_star <- max(best_logp[T_unsup]);
+    log_p_y_star = max(best_logp[T_unsup]);
     for (k in 1:K)
       if (best_logp[T_unsup,k] == log_p_y_star)
-        y_star[T_unsup] <- k;
+        y_star[T_unsup] = k;
     for (t in 1:(T_unsup - 1))
-      y_star[T_unsup - t] <- back_ptr[T_unsup - t + 1,
+      y_star[T_unsup - t] = back_ptr[T_unsup - t + 1,
                                       y_star[T_unsup - t + 1]];
   }
 }

--- a/misc/hmm/hmm-semisup.stan
+++ b/misc/hmm/hmm-semisup.stan
@@ -14,7 +14,7 @@ parameters {
   simplex[V] phi[K];    // emit probs
 }
 model {
-  for (k in 1:K) 
+  for (k in 1:K)
     theta[k] ~ dirichlet(alpha);
   for (k in 1:K)
     phi[k] ~ dirichlet(beta);
@@ -23,7 +23,7 @@ model {
   for (t in 2:T)
     z[t] ~ categorical(theta[z[t-1]]);
 
-  { 
+  {
     // forward algorithm computes log p(u|...)
     real acc[K];
     real gamma[T_unsup,K];
@@ -42,11 +42,10 @@ model {
 generated quantities {
   int<lower=1,upper=K> y_star[T_unsup];
   real log_p_y_star;
-  { 
+  {
     // Viterbi algorithm
     int back_ptr[T_unsup,K];
     real best_logp[T_unsup,K];
-    real best_total_logp;
     for (k in 1:K)
       best_logp[1,K] <- log(phi[k,u[1]]);
     for (t in 2:T_unsup) {
@@ -67,7 +66,7 @@ generated quantities {
       if (best_logp[T_unsup,k] == log_p_y_star)
         y_star[T_unsup] <- k;
     for (t in 1:(T_unsup - 1))
-      y_star[T_unsup - t] <- back_ptr[T_unsup - t + 1, 
+      y_star[T_unsup - t] <- back_ptr[T_unsup - t + 1,
                                       y_star[T_unsup - t + 1]];
   }
 }

--- a/misc/hmm/hmm-sufficient.stan
+++ b/misc/hmm/hmm-sufficient.stan
@@ -10,23 +10,23 @@ data {
 transformed data {
   int<lower=0> trans[K,K];
   int<lower=0> emit[K,V];
-  for (k1 in 1:K) 
+  for (k1 in 1:K)
     for (k2 in 1:K)
-      trans[k1,k2] <- 0;
+      trans[k1,k2] = 0;
   for (t in 2:T)
-    trans[z[t - 1], z[t]] <- 1 + trans[z[t - 1], z[t]];
+    trans[z[t - 1], z[t]] = 1 + trans[z[t - 1], z[t]];
   for (k in 1:K)
     for (v in 1:V)
-      emit[k,v] <- 0;
+      emit[k,v] = 0;
   for (t in 1:T)
-    emit[z[t], w[t]] <- 1 + emit[z[t], w[t]];
+    emit[z[t], w[t]] = 1 + emit[z[t], w[t]];
 }
 parameters {
   simplex[K] theta[K];  // transit probs
   simplex[V] phi[K];    // emit probs
 }
 model {
-  for (k in 1:K) 
+  for (k in 1:K)
     theta[k] ~ dirichlet(alpha);
   for (k in 1:K)
     phi[k] ~ dirichlet(beta);


### PR DESCRIPTION
There are some minor issues with the HMM example models. One of the models defines a variable called `best_total_logp` that is never used and there are some deprecated features that are used (e.g. assignment operators). The purpose of this pull request is to fix these issues.

Note that the definition of `best_total_logp` also occurs in the documentation but I am not sure which repository that is created in and where that should be fixed.