### PR TITLE
Fix capture-recapture likelihoods

### DIFF
--- a/BPA/Ch.06/Mb.stan
+++ b/BPA/Ch.06/Mb.stan
@@ -50,7 +50,7 @@ model {
               + bernoulli_lpmf(y[i] |  p_eff[i]);
     else // s[i] == 0
       target += log_sum_exp(bernoulli_lpmf(1 |  omega)   // z[i] == 1
-                            + bernoulli_lpmf(0 | p_eff[i]),
+                            + bernoulli_lpmf(y[i] | p_eff[i]),
                             bernoulli_lpmf(0 | omega));  // z[i] == 0
 }
 

--- a/BPA/Ch.06/Mt.stan
+++ b/BPA/Ch.06/Mt.stan
@@ -34,7 +34,7 @@ model {
               + bernoulli_lpmf(y[i] | p);
     else // s[i] == 0
       target += log_sum_exp(bernoulli_lpmf(1 | omega)   // z[i] == 1
-                            + bernoulli_lpmf(0 | p),
+                            + bernoulli_lpmf(y[i] | p),
                             bernoulli_lpmf(0 | omega)); // z[i] == 0
 }
 

--- a/BPA/Ch.06/MtX.stan
+++ b/BPA/Ch.06/MtX.stan
@@ -54,7 +54,7 @@ model {
               + bernoulli_logit_lpmf(y[i] | logit_p[i]);
     else // s[i] == 0
       target += log_sum_exp(bernoulli_lpmf(1 | omega)   // z[i] == 1
-                            + bernoulli_logit_lpmf(0 | logit_p[i]),
+                            + bernoulli_logit_lpmf(y[i] | logit_p[i]),
                             bernoulli_lpmf(0 | omega)); // z[i] == 0
 }
 

--- a/BPA/Ch.06/Mtbh.stan
+++ b/BPA/Ch.06/Mtbh.stan
@@ -59,7 +59,7 @@ model {
               + bernoulli_logit_lpmf(y[i] | logit_p[i]);
     else // s[i] == 0
       target += log_sum_exp(bernoulli_lpmf(1 | omega)   // z[i] == 1
-                            + bernoulli_logit_lpmf(0 | logit_p[i]),
+                            + bernoulli_logit_lpmf(y[i] | logit_p[i]),
                             bernoulli_lpmf(0 | omega)); // z[i] == 0
 }
 

--- a/BPA/Ch.06/Mth.stan
+++ b/BPA/Ch.06/Mth.stan
@@ -51,7 +51,7 @@ model {
               + bernoulli_logit_lpmf(y[i] | logit_p[i]);
     else // s[i] == 0
       target += log_sum_exp(bernoulli_lpmf(1 | omega)   // z[i] == 1
-                            + bernoulli_logit_lpmf(0 | logit_p[i]),
+                            + bernoulli_logit_lpmf(y[i] | logit_p[i]),
                             bernoulli_lpmf(0 | omega)); // z[i] == 0
   }
 }


### PR DESCRIPTION
A bug in capture-recapture likelihoods implied only one non-detection for individuals that may or may not be in the population, when in fact we have T non-detections (one for each sampling occasion). Issue described in #204.