### PR TITLE
Fix broken models and add CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,41 @@
+name: Compile models
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+    
+    - uses: actions/checkout@v2
+      with:
+       repository: 'stan-dev/performance-tests-cmdstan'
+       submodules: recursive
+    
+    - uses: actions/checkout@v2
+      with:
+        path: 'example-models-new'
+        fetch-depth: 0
+    
+    - name: Write modified models
+      run: |
+        cd example-models-new > ../test-models.txt
+        echo "example-models-new/basic_distributions/binormal.stan" > ../test-models.txt
+        git diff --name-only origin/master $GITHUB_SHA --diff-filter=AM | grep ".stan$" |  sed -e 's/^/example-models-new\//' >> ../test-models.txt
+
+    - name: Compile all new or modified models
+      run: |
+        cd cmdstan
+        make build
+        cd ..
+        ./runPerformanceTests.py --runs=0 --tests-file test-models.txt  

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -29,7 +29,7 @@ jobs:
     
     - name: Write modified models
       run: |
-        cd example-models-new > ../test-models.txt
+        cd example-models-new
         echo "example-models-new/basic_distributions/binormal.stan" > ../test-models.txt
         git diff --name-only origin/master $GITHUB_SHA --diff-filter=AM | grep ".stan$" |  sed -e 's/^/example-models-new\//' >> ../test-models.txt
 

--- a/knitr/bandits/bernoulli-ab.stan
+++ b/knitr/bandits/bernoulli-ab.stan
@@ -11,6 +11,10 @@ model {
 }
 generated quantities {
   int<lower = 0, upper = 1> is_best[K];
-  for (k in 1:K)
-    is_best[k] = (theta[k] >= best_prob);
+  {
+    real best_prob = max(theta);
+    for (k in 1:K) {
+      is_best[k] = (theta[k] >= best_prob);
+    }    
+  }  
 }

--- a/knitr/car-iar-poisson/pois_icar.stan
+++ b/knitr/car-iar-poisson/pois_icar.stan
@@ -28,7 +28,7 @@ model {
   beta0 ~ normal(0.0, 1.0);
   beta1 ~ normal(0.0, 1.0);
   sigma ~ normal(0.0, 1.0);
-  phi ~ icar_normal_lpdf(N, node1, node2);
+  phi ~ icar_normal(N, node1, node2);
   // soft sum-to-zero constraint on phi
   // more efficient than mean(phi) ~ normal(0, 0.001)
   sum(phi) ~ normal(0, 0.001 * N);

--- a/knitr/neural-nets/nn.stan
+++ b/knitr/neural-nets/nn.stan
@@ -39,7 +39,8 @@ model {
   to_vector(beta) ~ normal(0, 2);
 
   // likelihood
-  y[n] ~ categorical_logit(v[ , n]);
+  for (n in 1:N)
+    y[n] ~ categorical_logit(v[ , n]);
 }
 
 


### PR DESCRIPTION
- fixes broken models (not compiling): 
   - knitr/bandits/bernoulli-ab.stan
   - knitr/car-iar-poisson/pois_icar.stan
   - knitr/neural-nets/nn.stan

I think the fixes are correct (based on similar models in the subfolders).

Adds Continous integration that will try to compile all modified or added models.