### PR TITLE
rename quantile udf function to avoid name clash with math

### DIFF
--- a/education/causal_rct/Model_01_Assuming_Independent_Potential_Outcomes.stan
+++ b/education/causal_rct/Model_01_Assuming_Independent_Potential_Outcomes.stan
@@ -1,5 +1,5 @@
 functions { 
-  real quantile(vector x, real p){
+  real quantile_user_defined(vector x, real p){
     int n;            // length of vector x
     real index;       // integer index of p
     int lo;           // lower integer cap of the index
@@ -61,9 +61,9 @@ generated quantities{
     tau_unit[n] = y1[n] - y0[n];
   }
   tau_fs = mean(tau_unit);
-  tau_qte25 = quantile(to_vector(y1), 0.25) - quantile(to_vector(y0), 0.25); 
-  tau_qte50 = quantile(to_vector(y1), 0.50) - quantile(to_vector(y0), 0.50); 
-  tau_qte75 = quantile(to_vector(y1), 0.75) - quantile(to_vector(y0), 0.75); 
+  tau_qte25 = quantile_user_defined(to_vector(y1), 0.25) - quantile_user_defined(to_vector(y0), 0.25); 
+  tau_qte50 = quantile_user_defined(to_vector(y1), 0.50) - quantile_user_defined(to_vector(y0), 0.50); 
+  tau_qte75 = quantile_user_defined(to_vector(y1), 0.75) - quantile_user_defined(to_vector(y0), 0.75); 
 }
 
 

--- a/education/causal_rct/Model_02_Assuming_Constant_Treatment_Effects.stan
+++ b/education/causal_rct/Model_02_Assuming_Constant_Treatment_Effects.stan
@@ -1,5 +1,5 @@
 functions { 
-  real quantile(vector x, real p){
+  real quantile_user_defined(vector x, real p){
     int n;            // length of vector x
     real index;       // integer index of p
     int lo;           // lower integer cap of the index
@@ -58,9 +58,9 @@ generated quantities{
     tau_unit[n] = y1[n] - y0[n];
   }
   tau_fs = mean(tau_unit);
-  tau_qte25 = quantile(to_vector(y1), 0.25) - quantile(to_vector(y0), 0.25); 
-  tau_qte50 = quantile(to_vector(y1), 0.50) - quantile(to_vector(y0), 0.50); 
-  tau_qte75 = quantile(to_vector(y1), 0.75) - quantile(to_vector(y0), 0.75); 
+  tau_qte25 = quantile_user_defined(to_vector(y1), 0.25) - quantile_user_defined(to_vector(y0), 0.25); 
+  tau_qte50 = quantile_user_defined(to_vector(y1), 0.50) - quantile_user_defined(to_vector(y0), 0.50); 
+  tau_qte75 = quantile_user_defined(to_vector(y1), 0.75) - quantile_user_defined(to_vector(y0), 0.75); 
 }
 
 

--- a/education/causal_rct/Model_03_Independent_Potential_Outcomes_With_Covariates.stan
+++ b/education/causal_rct/Model_03_Independent_Potential_Outcomes_With_Covariates.stan
@@ -1,5 +1,5 @@
 functions { 
-  real quantile(vector x, real p){
+  real quantile_user_defined(vector x, real p){
     int n;            // length of vector x
     real index;       // integer index of p
     int lo;           // lower integer cap of the index
@@ -68,9 +68,9 @@ generated quantities{
     tau_unit[n] = y1[n] - y0[n];
   }
   tau_fs = mean(tau_unit);
-  tau_qte25 = quantile(to_vector(y1), 0.25) - quantile(to_vector(y0), 0.25);
-  tau_qte50 = quantile(to_vector(y1), 0.50) - quantile(to_vector(y0), 0.50);
-  tau_qte75 = quantile(to_vector(y1), 0.75) - quantile(to_vector(y0), 0.75);
+  tau_qte25 = quantile_user_defined(to_vector(y1), 0.25) - quantile_user_defined(to_vector(y0), 0.25);
+  tau_qte50 = quantile_user_defined(to_vector(y1), 0.50) - quantile_user_defined(to_vector(y0), 0.50);
+  tau_qte75 = quantile_user_defined(to_vector(y1), 0.75) - quantile_user_defined(to_vector(y0), 0.75);
 }
 
 

--- a/education/causal_rct/Model_04_Independent_Potential_Outcomes_with_Covariates-Two-Part-Model.stan
+++ b/education/causal_rct/Model_04_Independent_Potential_Outcomes_with_Covariates-Two-Part-Model.stan
@@ -1,5 +1,5 @@
 functions { 
-  real quantile(vector x, real p){
+  real quantile_user_defined(vector x, real p){
     int n;            // length of vector x
     real index;       // integer index of p
     int lo;           // lower integer cap of the index
@@ -130,9 +130,9 @@ generated quantities{
     tau_samp = mean(tau_ind);
     
     // store QTEs
-    tau_qte25 = quantile(to_vector(y1), 0.25) - quantile(to_vector(y0), 0.25); 
-    tau_qte50 = quantile(to_vector(y1), 0.50) - quantile(to_vector(y0), 0.50); 
-    tau_qte75 = quantile(to_vector(y1), 0.75) - quantile(to_vector(y0), 0.75); 
+    tau_qte25 = quantile_user_defined(to_vector(y1), 0.25) - quantile_user_defined(to_vector(y0), 0.25); 
+    tau_qte50 = quantile_user_defined(to_vector(y1), 0.50) - quantile_user_defined(to_vector(y0), 0.50); 
+    tau_qte75 = quantile_user_defined(to_vector(y1), 0.75) - quantile_user_defined(to_vector(y0), 0.75); 
   } // end temporary variables
 }
 


### PR DESCRIPTION
In https://github.com/stan-dev/stanc3/pull/870 we expose a quantile function, which caused a named clash with 4 example models.

This fixes the name clashes by renaming the `quantile` function in the models to `quantile_user_defined`.