### PR TITLE
update case study of hierarchical models for binary trials 

### DIFF
--- a/knitr/pool-binary-trials/hier-logit-centered.stan
+++ b/knitr/pool-binary-trials/hier-logit-centered.stan
@@ -15,9 +15,5 @@ model {
   y ~ binomial_logit(K, alpha); // likelihood
 }
 generated quantities {
-  vector[N] theta; // chance of success
-  
-  for (n in 1 : N) {
-    theta[n] = inv_logit(alpha[n]);
-  }
+  vector[N] theta = inv_logit(alpha);
 }

--- a/knitr/pool-binary-trials/hier-logit.stan
+++ b/knitr/pool-binary-trials/hier-logit.stan
@@ -1,106 +1,22 @@
-data {
-  int<lower=0> N; // items
-  array[N] int<lower=0> K; // initial trials
-  array[N] int<lower=0> y; // initial successes
-  
-  array[N] int<lower=0> K_new; // new trials
-  array[N] int<lower=0> y_new; // new successes
-}
-transformed data {
-  real min_y; // minimum successes
-  real max_y; // maximum successes
-  real mean_y; // sample mean successes
-  real sd_y; // sample std dev successes
-  
-  min_y = min(y);
-  max_y = max(y);
-  mean_y = mean(to_vector(y));
-  sd_y = sd(to_vector(y));
-}
+#include data-blocks.stan
 parameters {
   real mu; // population mean of success log-odds
   real<lower=0> sigma; // population sd of success log-odds
-  vector[N] alpha_std; // success log-odds (standardized)
+  vector<offset=mu, multiplier=sigma>[N] alpha_std; // success log-odds (standardized)
 }
 model {
   mu ~ normal(-1, 1); // hyperprior
   sigma ~ normal(0, 1); // hyperprior
-  alpha_std ~ normal(0, 1); // prior (hierarchical)
-  y ~ binomial_logit(K, mu + sigma * alpha_std); // likelihood
+  alpha_std ~ normal(mu, sigma); // prior (hierarchical)
+  y ~ binomial_logit(K, alpha_std); // likelihood
 }
 generated quantities {
-  vector[N] theta; // chance of success
-  
-  real log_p_new; // posterior predictive log density remaining trials
-  
-  array[N] int<lower=0> z; // posterior prediction remaining trials
-  
-  int<lower=0, upper=1> some_ability_gt_350; // Pr[some theta > 0.35]
-  array[N] int<lower=0, upper=1> avg_gt_400; // Pr[season avg of n] >= 0.400
-  array[N] int<lower=0, upper=1> ability_gt_400; // Pr[chance-of-success of n] >= 0.400
-  
-  array[N] int<lower=1, upper=N> rnk; // rank of player n
-  array[N] int<lower=0, upper=1> is_best; // Pr[player n highest chance of success]
-  
-  array[N] int<lower=0> y_rep; // replications for existing items
+  vector[N] theta = inv_logit(alpha_std);
+  #include gq-postpred.stan
+  #include gq-ranking.stan
+
   array[N] int<lower=0> y_pop_rep; // replications for simulated items
-  
-  real min_y_rep; // posterior predictive min replicated successes
-  real max_y_rep; // posterior predictive max replicated successes
-  real mean_y_rep; // posterior predictive sample mean replicated successes
-  real sd_y_rep; // posterior predictive sample std dev replicated successes
-  
-  int p_min; // posterior predictive p-values
-  int p_max;
-  int p_mean;
-  int p_sd;
-  
-  for (n in 1 : N) {
-    theta[n] = inv_logit(mu + sigma * alpha_std[n]);
-  }
-  
-  log_p_new = 0;
-  for (n in 1 : N) {
-    log_p_new = log_p_new + binomial_lpmf(y_new[n] | K_new[n], theta[n]);
-  }
-  
-  for (n in 1 : N) {
-    z[n] = binomial_rng(K_new[n], theta[n]);
-  }
-  
-  some_ability_gt_350 = max(theta) > 0.35;
-  for (n in 1 : N) {
-    avg_gt_400[n] = ((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400;
-  }
-  for (n in 1 : N) {
-    ability_gt_400[n] = theta[n] > 0.400;
-  }
-  
-  {
-    array[N] int dsc;
-    dsc = sort_indices_desc(theta);
-    for (n in 1 : N) {
-      rnk[dsc[n]] = n;
-    }
-  }
-  for (n in 1 : N) {
-    is_best[n] = rnk[n] == 1;
-  }
-  
-  for (n in 1 : N) {
-    y_rep[n] = binomial_rng(K[n], theta[n]);
-  }
   for (n in 1 : N) {
     y_pop_rep[n] = binomial_rng(K[n], inv_logit(normal_rng(mu, sigma)));
   }
-  
-  min_y_rep = min(y_rep);
-  max_y_rep = max(y_rep);
-  mean_y_rep = mean(to_vector(y_rep));
-  sd_y_rep = sd(to_vector(y_rep));
-  
-  p_min = min_y_rep >= min_y;
-  p_max = max_y_rep >= max_y;
-  p_mean = mean_y_rep >= mean_y;
-  p_sd = sd_y_rep >= sd_y;
 }

--- a/knitr/pool-binary-trials/hier.stan
+++ b/knitr/pool-binary-trials/hier.stan
@@ -1,22 +1,4 @@
-data {
-  int<lower=0> N; // items
-  array[N] int<lower=0> K; // initial trials
-  array[N] int<lower=0> y; // initial successes
-  
-  array[N] int<lower=0> K_new; // new trials
-  array[N] int<lower=0> y_new; // new successes
-}
-transformed data {
-  real min_y; // minimum successes
-  real max_y; // maximum successes
-  real mean_y; // sample mean successes
-  real sd_y; // sample std dev successes
-  
-  min_y = min(y);
-  max_y = max(y);
-  mean_y = mean(to_vector(y));
-  sd_y = sd(to_vector(y));
-}
+#include data-blocks.stan
 parameters {
   real<lower=0, upper=1> phi; // population chance of success
   real<lower=1> kappa; // population concentration
@@ -28,73 +10,13 @@ model {
   y ~ binomial(K, theta); // likelihood
 }
 generated quantities {
-  real log_p_new; // posterior predictive log density remaining trials
-  
-  array[N] int<lower=0> z; // posterior prediction remaining trials
-  
-  int<lower=0, upper=1> some_ability_gt_350; // Pr[some theta > 0.35]
-  array[N] int<lower=0, upper=1> avg_gt_400; // Pr[season avg of n] >= 0.400
-  array[N] int<lower=0, upper=1> ability_gt_400; // Pr[chance-of-success of n] >= 0.400
-  
-  array[N] int<lower=1, upper=N> rnk; // rank of player n
-  array[N] int<lower=0, upper=1> is_best; // Pr[player n highest chance of success]
-  
-  array[N] int<lower=0> y_rep; // replications for existing items
-  array[N] int<lower=0> y_pop_rep; // replications for simulated items
-  
-  real min_y_rep; // posterior predictive min replicated successes
-  real max_y_rep; // posterior predictive max replicated successes
-  real mean_y_rep; // posterior predictive sample mean replicated successes
-  real sd_y_rep; // posterior predictive sample std dev replicated successes
-  
-  int p_min; // posterior predictive p-values
-  int p_max;
-  int p_mean;
-  int p_sd;
-  
-  log_p_new = 0;
-  for (n in 1 : N) {
-    log_p_new = log_p_new + binomial_lpmf(y_new[n] | K_new[n], theta[n]);
-  }
-  
-  for (n in 1 : N) {
-    z[n] = binomial_rng(K_new[n], theta[n]);
-  }
-  
-  some_ability_gt_350 = max(theta) > 0.35;
-  for (n in 1 : N) {
-    avg_gt_400[n] = ((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400;
-  }
-  for (n in 1 : N) {
-    ability_gt_400[n] = theta[n] > 0.400;
-  }
-  
-  {
-    array[N] int dsc;
-    dsc = sort_indices_desc(theta);
-    for (n in 1 : N) {
-      rnk[dsc[n]] = n;
-    }
-  }
-  for (n in 1 : N) {
-    is_best[n] = rnk[n] == 1;
-  }
-  
-  for (n in 1 : N) {
-    y_rep[n] = binomial_rng(K[n], theta[n]);
-  }
+  #include gq-postpred.stan
+  #include gq-ranking.stan
+
+  // replications for simulated items  
+  array[N] int<lower=0> y_pop_rep; 
   for (n in 1 : N) {
     y_pop_rep[n] = binomial_rng(K[n],
                                 beta_rng(phi * kappa, (1 - phi) * kappa));
   }
-  
-  min_y_rep = min(y_rep);
-  max_y_rep = max(y_rep);
-  mean_y_rep = mean(to_vector(y_rep));
-  sd_y_rep = sd(to_vector(y_rep));
-  
-  p_min = min_y_rep >= min_y;
-  p_max = max_y_rep >= max_y;
-  p_mean = mean_y_rep >= mean_y;
-  p_sd = sd_y_rep >= sd_y;
 }

--- a/knitr/pool-binary-trials/include/data-blocks.stan
+++ b/knitr/pool-binary-trials/include/data-blocks.stan
@@ -1,0 +1,16 @@
+/** observed outcome y for N items in K, K_new binary trials **/
+data {
+  int<lower=0> N; // items
+  array[N] int<lower=0> K; // initial trials
+  array[N] int<lower=0> y; // initial successes
+  
+  array[N] int<lower=0> K_new; // new trials
+  array[N] int<lower=0> y_new; // new successes
+}
+transformed data {
+  // summary stats for observed data
+  real min_y = min(y);
+  real max_y = max(y);
+  real mean_y = mean(to_vector(y));
+  real sd_y = sd(to_vector(y));
+}

--- a/knitr/pool-binary-trials/include/gq-postpred.stan
+++ b/knitr/pool-binary-trials/include/gq-postpred.stan
@@ -1,0 +1,46 @@
+/** include in generated quantities block of model with parameter
+    vector<lower=0, upper=1>[N] theta; // chance of success 
+    and data: N, K, y, K_new, y_new, min_y, max_y, mean_y, sd_y
+*/
+
+  // posterior predictive log density remaining trials
+  real log_p_new = 0;
+  for (n in 1 : N) {
+    log_p_new = log_p_new + binomial_lpmf(y_new[n] | K_new[n], theta[n]);
+  }
+
+  // posterior predictions on new data 
+  array[N] int<lower=0> z = binomial_rng(K_new, theta); 
+
+  // Pr[some theta > 0.35]  
+  int<lower=0, upper=1> some_ability_gt_350 = max(theta) > 0.35;
+  // Pr[some player ability > 400]
+  array[N] int<lower=0, upper=1> ability_gt_400;
+  for (n in 1 : N) {
+    ability_gt_400[n] = theta[n] > 0.400;
+  }
+  // Pr[some player season average > 400]
+  array[N] int<lower=0, upper=1> avg_gt_400;
+  for (n in 1 : N) {
+    // y[n] - observed, z[n] - expected hits in rest of season
+    avg_gt_400[n] = ((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400;
+  }
+
+  // replications for existing items  
+  array[N] int<lower=0> y_rep = binomial_rng(K, theta);
+  
+  // posterior predictive min replicated successes, test stat p_val
+  real<lower=0> min_y_rep = min(y_rep);
+  int<lower=0, upper=1> p_min = min_y_rep >= min_y;
+
+  // posterior predictive max replicated successes, test stat p_val
+  real<lower=0> max_y_rep = max(y_rep); 
+  int<lower=0, upper=1> p_max = max_y_rep >= max_y;
+
+  // posterior predictive sample mean replicated successes, test stat p_val
+  real<lower=0> mean_y_rep = mean(to_vector(y_rep));
+  int<lower=0, upper=1> p_mean = mean_y_rep >= mean_y;
+
+  // posterior predictive sample std dev replicated successes, test stat p_val
+  real<lower=0> sd_y_rep = sd(to_vector(y_rep));
+  int<lower=0, upper=1> p_sd = sd_y_rep >= sd_y;

--- a/knitr/pool-binary-trials/include/gq-ranking.stan
+++ b/knitr/pool-binary-trials/include/gq-ranking.stan
@@ -1,0 +1,16 @@
+/** include in generated quantities block of model with parameter
+    vector<lower=0, upper=1>[N] theta; // chance of success
+    and data N (number of observations)
+*/
+  array[N] int<lower=1, upper=N> rnk; // rank of player n
+  {
+    array[N] int dsc;
+    dsc = sort_indices_desc(theta);
+    for (n in 1 : N) {
+      rnk[dsc[n]] = n;
+    }
+  }
+  array[N] int<lower=0, upper=1> is_best; // Pr[player n highest chance of success]
+  for (n in 1 : N) {
+    is_best[n] = rnk[n] == 1;
+  }

--- a/knitr/pool-binary-trials/no-pool.stan
+++ b/knitr/pool-binary-trials/no-pool.stan
@@ -1,22 +1,4 @@
-data {
-  int<lower=0> N; // items
-  array[N] int<lower=0> K; // initial trials
-  array[N] int<lower=0> y; // initial successes
-  
-  array[N] int<lower=0> K_new; // new trials
-  array[N] int<lower=0> y_new; // new successes
-}
-transformed data {
-  real min_y; // minimum successes
-  real max_y; // maximum successes
-  real mean_y; // sample mean successes
-  real sd_y; // sample std dev successes
-  
-  min_y = min(y);
-  max_y = max(y);
-  mean_y = mean(to_vector(y));
-  sd_y = sd(to_vector(y));
-}
+#include data-blocks.stan
 parameters {
   vector<lower=0, upper=1>[N] theta; // chance of success
 }
@@ -24,68 +6,6 @@ model {
   y ~ binomial(K, theta); // likelihood
 }
 generated quantities {
-  real log_p_new; // posterior predictive log density remaining trials
-  
-  array[N] int<lower=0> z; // posterior prediction remaining trials
-  
-  int<lower=0, upper=1> some_ability_gt_350; // Pr[some theta > 0.35]
-  array[N] int<lower=0, upper=1> avg_gt_400; // Pr[season avg of n] >= 0.400
-  array[N] int<lower=0, upper=1> ability_gt_400; // Pr[chance-of-success of n] >= 0.400
-  
-  array[N] int<lower=1, upper=N> rnk; // rank of player n
-  array[N] int<lower=0, upper=1> is_best; // Pr[player n highest chance of success]
-  
-  array[N] int<lower=0> y_rep; // replications for existing items
-  
-  real min_y_rep; // posterior predictive min replicated successes
-  real max_y_rep; // posterior predictive max replicated successes
-  real mean_y_rep; // posterior predictive sample mean replicated successes
-  real sd_y_rep; // posterior predictive sample std dev replicated successes
-  
-  int p_min; // posterior p-val for min test stat
-  int p_max; // posterior p-val for max test stat
-  int p_mean; // posterior p-val for sample mean test stat
-  int p_sd; // posterior p-val for smaple std dev test stat
-  
-  log_p_new = 0;
-  for (n in 1 : N) {
-    log_p_new = log_p_new + binomial_lpmf(y_new[n] | K_new[n], theta[n]);
-  }
-  
-  for (n in 1 : N) {
-    z[n] = binomial_rng(K_new[n], theta[n]);
-  }
-  
-  some_ability_gt_350 = max(theta) > 0.35;
-  for (n in 1 : N) {
-    avg_gt_400[n] = ((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400;
-  }
-  for (n in 1 : N) {
-    ability_gt_400[n] = theta[n] > 0.400;
-  }
-  
-  {
-    array[N] int dsc;
-    dsc = sort_indices_desc(theta);
-    for (n in 1 : N) {
-      rnk[dsc[n]] = n;
-    }
-  }
-  for (n in 1 : N) {
-    is_best[n] = rnk[n] == 1;
-  }
-  
-  for (n in 1 : N) {
-    y_rep[n] = binomial_rng(K[n], theta[n]);
-  }
-  
-  min_y_rep = min(y_rep);
-  max_y_rep = max(y_rep);
-  mean_y_rep = mean(to_vector(y_rep));
-  sd_y_rep = sd(to_vector(y_rep));
-  
-  p_min = min_y_rep >= min_y;
-  p_max = max_y_rep >= max_y;
-  p_mean = mean_y_rep >= mean_y;
-  p_sd = sd_y_rep >= sd_y;
+  #include gq-postpred.stan
+  #include gq-ranking.stan
 }

--- a/knitr/pool-binary-trials/pool-no-pool.Rmd
+++ b/knitr/pool-binary-trials/pool-no-pool.Rmd
@@ -1,11 +1,10 @@
----
-title: "Hierarchical Partial Pooling for Repeated Binary Trials"
-author: "Bob Carpenter"
-date: "29 January 2016"
-output: 
-  html_document: 
-    theme: readable
----
+## Hierarchical Partial Pooling for Repeated Binary Trials in CmdStanR
+
+*Bob Carpenter* <br>
+29 January 2016
+
+updated for CmdStanR by Mitzi Morris, 19 January 2022
+
 
 ### Abstract
 
@@ -18,13 +17,45 @@ unrelated, and (c) partial pooling, where the similarity among the
 items is estimated.  We consider two hierarchical models to estimate
 the partial pooling, one with a beta prior on chance of success and
 another with a normal prior on the log odds of success.  The note
-explains with working examples how to (i) fit models in RStan and plot
-the results in R using ggplot2, (ii) estimate event probabilities,
-(iii) evaluate posterior predictive densities to evaluate model
-predictions on held-out data, (iv) rank items by chance of success,
-(v) perform multiple comparisons in several settings, (vi) replicate
-new data for posterior p-values, and (vii) perform graphical posterior
-predictive checks.
+explains with working examples how to
+
+- (i) fit models in [CmdStanR](https://mc-stan.org/cmdstanr) and plot the results in R using ggplot2,
+- (ii) estimate event probabilities,
+- (iii) evaluate posterior predictive densities to evaluate model predictions on held-out data, (iv) rank items by chance of success,
+- (v) perform multiple comparisons in several settings,
+- (vi) replicate new data for posterior p-values, and (vii) perform graphical posterior predictive checks.
+
+
+### Packages used in this notebook
+
+In this notebook, we will use the [CmdStanR interface](https://mc-stan.org/cmdstanr/).
+
+```{r comment=NA}
+#library(devtools);
+#if(!require(cmdstanr)){
+#    devtools::install_github("stan-dev/cmdstanr", dependencies=c("Depends", "Imports"))
+#}
+options(warn=-1)
+options(repr.plot.width=8, repr.plot.height=8)
+library(tidyverse)
+library(posterior)
+library(cmdstanr)
+set_cmdstan_path("/Users/mitzi/.cmdstan/cmdstan-2.28.2")
+```
+```{r echo=FALSE}
+theme_jupyter <- function() {
+  theme_grey() + 
+  theme(text = element_text(size=18),
+        plot.title = element_text(size=24),
+        plot.subtitle = element_text(size=20),
+        axis.title.x = element_text(size=20),
+        axis.title.y = element_text(size=20),
+        strip.text.x = element_text(size=18),
+        strip.text.y = element_text(size=18)
+       );
+}
+```
+
 
 ## Repeated Binary Trials
 
@@ -72,11 +103,13 @@ remaining hits and at bats to evaluate the predictive inferences for
 the various models.
 
 ```{r comment=NA}
+M <- 10000  # total draws in the sample
 N <- dim(df)[1]
 K <- df$At.Bats
 y <- df$Hits
 K_new <- df$RemainingAt.Bats;
 y_new <- df$RemainingHits;
+names <- paste(seq(1:18), df$FirstName, df$LastName);
 ```
 
 The data separates the outcome from the initial 45 at-bats from the
@@ -160,33 +193,27 @@ due to numerical arithmetic issues.
 
 Assuming each player's at-bats are independent Bernoulli trials, the
 sampling distribution for each player's number of hits $y_n$ is modeled as
-
-\[
+$$
 p(y_n \, | \, \phi) 
 \ = \
 \mathsf{Binomial}(y_n \, | \, K_n, \phi).
-\]
-
+$$
 When viewed as a function of $\phi$ for fixed $y_n$, this is called
 the likelihood function.  
 
 Assuming each player is independent leads to the complete data
 likelihood
-
-\[
+$$
 p(y \, | \, \phi) = \prod_{n=1}^N \mathsf{Binomial}(y_n \, | \, K_n, \phi).
-\]
-
+$$
 We will assume a uniform prior on $\phi$,
-
-\[
+$$
 p(\phi) 
 \ = \
 \mathsf{Uniform}(\phi \, | \, 0, 1) 
 \ = \
 1.
-\]
-
+$$
 Whether a prior is uniform or not depends on the scale with which the
 parameter is expressed.  Here, the variable $\phi$ is a chance of
 success in $[0, 1]$.  If we were to consider the log-odds of success,
@@ -242,58 +269,72 @@ The actual Stan program in <code>pool.stan</code> has many more
 derived quantities that will be used in the rest of this note; see
 the appendix for the full code of all of the models discussed.
 
-We start by loading the RStan package.
 
-```{r comment=NA}
-library(rstan);
+We wish to create a posterior sample of size 10,000 draws.
+To do this we first call the `cmdstan_model()` function which instantiates a CmdStanModel object from a file containing a Stan program.
+
+```{r}
+pool_model <- cmdstan_model(stan_file='pool.stan')
 ```
 
-The model can be fit as follows, with `M` being the total number of
+draws we first instantiate a
+To fit the model to the dataThe model can be fit as follows, with `M` being the total number of
 draws in the complete posterior sample (each chain is by default split
 into half warmup and half sampling iterations and 4 chains are being
 run).
 
+To fit the model we first create a named list containing the values for all input data variables.
+By default, CmdStanR runs 4 chains with 1000 warmup and sampling iterations per chain.
+To generate a sample of 10,000 draws, we specify the per-chain number of sampling iterations to be 2500.
+
 ```{r comment=NA}
-M <- 10000;
-fit_pool <- stan("pool.stan", data=c("N", "K", "y", "K_new", "y_new"),
-                 iter=(M / 2), chains=4);
-ss_pool <- extract(fit_pool);
+# These were computed in the 2nd code chunk above
+#N <- dim(df)[1]
+#K <- df$At.Bats
+#y <- df$Hits
+#K_new <- df$RemainingAt.Bats;
+#y_new <- df$RemainingHits;
+
+baseball_data = list(N=N, K=K, y=y, K_new=K_new, y_new=y_new)
+fit_pool <- pool_model$sample(data=baseball_data, iter_sampling=2500)
+
 ```
-
-Here, we read the data out of the environment by name; normally we
-would prefer to encapsulate the data in a list to avoid naming
-conflicts in the top-level namespace.  We showed the default output
-for the <code>stan()</code> function call here, but will suppress it
-in subsequent calls.
-
 
 The posterior sample for <code>phi</code> can be summarized as
 follows.
 
 ```{r comment=NA}
-print(fit_pool, c("phi"), probs=c(0.1, 0.5, 0.9));
+fit_pool$print('phi')
 ```
 
 The summary statistics begin with the posterior mean, the MCMC
 standard error on the posterior mean, and the posterior standard
-deviation.  Then there are 0.1, 0.5, and 0.9 quantiles, which provide
-the posterior median and boundaries of the central 80% interval.  The
-last two columns are for the effective sample size (MCMC standard
-error is the posterior standard deviation divided by the square root
-of the effective sample size) and the $\hat{R}$ convergence diagnostic
+deviation (sd) and mean average deviation (mad).
+Then there are the 0.5, and 0.95 quantiles, which provide
+the posterior median and boundaries of the central 90% interval.
+The next two columns are for the effective sample size for the
+central 90% interval and the tail.
+The final column is the $\hat{R}$ convergence diagnostic
 (its value will be 1 if the chains have all converged to the same
-posterior mean and variance; see the Stan Manual (Stan Development
-Team 2015) or (Gelman et al. 2013).  The $\hat{R}$ value here is
-consistent with convergence (i.e., near 1) and the effective sample
-size is good (roughly half the number of posterior draws; by default
-Stan uses as many iterations to warmup as it does for drawing the
-sample).
+posterior mean and variance; see the
+[Stan Reference Manual](https://mc-stan.org/docs/reference-manual/analysis.html),
+[Vehtari et al, 2021](https://projecteuclid.org/journals/bayesian-analysis/volume-16/issue-2/Rank-Normalization-Folding-and-Localization--An-Improved-Rˆ-for/10.1214/20-BA1221.full)
+and [its appendix](https://avehtari.github.io/rhat_ess/ess_comparison.html)
+for further discussion of these diagnostics.
+The $\hat{R}$ value here is
+consistent with convergence (i.e., near 1) and the effective sample size is good (well above 10%).
 
-The result is a posterior mean for $\theta$ of $0.27$ with an 80%
-central posterior interval of $(0.25, 0.29)$.  With more data, such as
+The result is a posterior mean for $\theta$ of $0.27$ with an 90%
+central posterior interval of $(0.24, 0.29)$.
+
+```{r}
+fit_pool$print('theta')
+```
+
+With more data, such as
 from more players or from the rest of the season, the posterior
 approaches a delta function around the maximum likelihood estimate and
-the posterior interval around the centeral posterior intervals will
+the posterior interval around the central posterior intervals will
 shrink.  Nevertheless, even if we know a player's chance of success
 exactly, there is a large amount of uncertainty in running $K$ binary
 trials with that chance of success; using a binomial model
@@ -312,29 +353,29 @@ parameter $\theta_n \in [0,1]$ for each item $n$.
 
 The prior on each $\theta_n$ is uniform,
 
-\[
+$
 p(\theta_n) = \mathsf{Uniform}(\theta_n \, | \, 0,1),
-\]
+$
 
 and the $\theta_n$ are assumed to be independent, 
 
-\[
+$
 p(\theta) = \prod_{n=1}^N \mathsf{Uniform}(\theta_n \, | \, 0,1).
-\]
+$
 
 The likelihood then uses the chance of success $\theta_n$ for item $n$
 in modeling the number of successes $y_n$ as
 
-\[
+$
 p(y_n \, | \, \theta_n) = \mathsf{Binomial}(y_n \, | \, K_n, \theta_n).
-\]
+$
 
 Assuming the $y_n$ are independent (conditional on $\theta$), this
 leads to the total data likelihood
 
-\[
+$
 p(y \, | \, \theta) = \prod_{n=1}^N \mathsf{Binomial}(y_n \, | \, K_n, \theta_n).
-\]
+$
 
 The Stan program for no pooling only differs in declaring the ability
 parameters as an $N$-vector rather than a scalar.
@@ -369,16 +410,16 @@ in <code>no-pool.stan</code>, which is shown in the appendix.
 
 This model can be fit the same way as the last model.
 
-```{r  comment=NA, results='hide'}
-fit_no_pool <- stan("no-pool.stan", data=c("N", "K", "y", "K_new", "y_new"),
-                    iter=(M / 2), chains=4);
-ss_no_pool <- extract(fit_no_pool);
+```{r results='hide', comment=NA}
+no_pool_model <- cmdstan_model(stan_file='no-pool.stan')
+fit_no_pool <- no_pool_model$sample(data=baseball_data, iter_sampling=2500)
+
 ```
 
-Results are displayed the same way.
+Now we examine the per-player chance of success `theta`
 
 ```{r comment=NA}
-print(fit_no_pool, c("theta"), probs=c(0.1, 0.5, 0.9));
+fit_no_pool$print('theta');
 ```
 
 Now there is a separate line for each item's estimated $\theta_n$.
@@ -388,14 +429,14 @@ median will be reasonably close to the posterior mode despite the
 skewness (the posterior can be shown analytically to be a Beta
 distribution).
 
-Each 80% interval is much wider than the estimated interval for the
+Each 90% interval is much wider than the estimated interval for the
 population in the complete pooling model; this is to be
 expected---there are only 45 data items for each parameter here as
 opposed to 810 in the complete pooling case.  If the items each had
 different numbers of trials, the intervals would also vary based on
 size.
 
-As the estimated chance of success goes up toward 0.5, the 80%
+As the estimated chance of success goes up toward 0.5, the 90%
 intervals gets wider.  This is to be expected for chance of success
 parameters, because the standard deviation of a random variable
 distributed as $\mathsf{Binomial}(K, \theta)$ is $\sqrt{\theta (1 - \theta) K}$.
@@ -436,10 +477,10 @@ assume a <a
 href="https://en.wikipedia.org/wiki/Beta_distribution">beta
 distribution</a> as the prior as it is scaled to values in $[0, 1]$,
 
-\[
+$
 p(\theta_n \, | \, \alpha, \beta)
 \ = \ \mathsf{Beta}(\theta_n \, | \, \alpha, \beta),
-\]
+$
 
 where $\alpha, \beta > 0$ are the parameters of the prior.  The beta
 distribution is the conjugate prior for the binomial, meaning that the
@@ -451,25 +492,25 @@ observations and thus a uniform distribution.  Each $\theta_n$ will be
 modeled as conditionally independent given the prior parameters, so
 that the complete prior is
 
-\[
+$
 p(\theta \, | \, \alpha, \beta) 
 = \prod_{n=1}^N \mathsf{Beta}(\theta_n \, | \, \alpha, \beta).
-\]
+$
 
 The parameters $\alpha$ and $\beta$ are themselves given priors
 (sometimes called hyperpriors).  Rather than parameterize $\alpha$ and
 $\beta$ directly, we will instead put priors on $\phi \in [0, 1]$
 and $\kappa > 0$, and then define
 
-\[
+$
 \alpha = \kappa \, \phi
-\]
+$
 
 and
 
-\[
+$
 \beta = \kappa \, (1 - \phi).
-\]
+$
 
 This reparameterization is convenient, because 
 
@@ -482,15 +523,15 @@ inversely related to the variance).
 We will follow Gelman et al. (2013, Chapter 5) in providing a prior
 that factors into a uniform prior on $\phi$,
 
-\[
+$
 p(\phi) = \mathsf{Uniform}(\phi \, | \, 0, 1), 
-\]
+$
 
 and a Pareto prior on $\kappa$,
 
-\[
+$
 p(\kappa) = \mathsf{Pareto}(\kappa \, | \, 1, 1.5) \propto \kappa^{-2.5}.
-\]
+$
 
 with the restriction $\kappa > 1$.  In general, for functions $f$ and
 $g$, we write $f(x) \propto g(x)$ if there is some constant $c$ such
@@ -534,19 +575,32 @@ explicitly constrained to lie in $[0, 1]$.  The prior on $\kappa$ is
 coded following the model definition. 
 
 The full model with all generated quantities can be coded in Stan as in
-the file <code>hier.stan</code>; it is displayed in the appendix.  It is run as usual.
+the file <code>hier.stan</code>; it is displayed in the appendix.  It is run as usual,
+except that this time we set the pseudorandom number generator seed here to 1234
+so that we can consistently generate the exact set of draws.
 
-```{r  comment=NA, results='hide'}
-fit_hier <- stan("hier.stan", data=c("N", "K", "y", "K_new", "y_new"),
-                 iter=(M / 2), chains=4,
-                 seed=1234);
-ss_hier <- extract(fit_hier);
+```{r results='hide', comment=NA}
+hier_model <- cmdstan_model(stan_file='hier.stan')
+fit_hier <- hier_model$sample(data=baseball_data, iter_sampling=2500, seed=1234)
 ```
 
-Even though we set <code>results='hide'</code> in the knitr R call
-here, the error messages are still printed.  We set the pseudorandom
-number generator seed here to 1234 so that we could discuss what the
-output looks like.  
+The console output contains a number of error messages of the form
+```
+
+Warning: 8 of 10000 (0.0%) transitions ended with a divergence.
+This may indicate insufficient exploration of the posterior distribution.
+Possible remedies include: 
+  * Increasing adapt_delta closer to 1 (default is 0.8) 
+  * Reparameterizing the model (e.g. using a non-centered parameterization)
+  * Using informative or weakly informative prior distributions 
+
+```
+
+CmdStan's [diagnose](https://mc-stan.org/docs/cmdstan-guide/diagnose.html) utility provides more checks on the MCMC sample.
+
+```{r}
+fit_hier$cmdstan_diagnose()
+```
 
 #### Divergent Transitions and Mitigation Strategies
 
@@ -573,34 +627,48 @@ in the gradient times the step size provides a poor approximation to
 the posterior curvature.  The problem with a hierarchical model is
 that the curvature in the posterior varies based on position; when the
 hierarchical variance is low, there is high curvature in the
-lower-level parameters around the mean.  During warmup, Stan globally
+lower-level parameters around the mean.
+During warmup, Stan globally
 adapts its step size to a target acceptance rate, which can lead to
 too large step sizes for highly curved regions of the posterior.  To
-mitigate this problem, we need to either reduce the step size or
-reparameterize.  We firt consider reducing step size, and then in the
-next secton consider the superior alternative of reparameterization.
+mitigate this problem, we need to either:
+ - increase the number of warmup iterations
+ - reduce the step size and increase the target acceptance rate
+ - reparameterize.
+ 
+We first consider the combination of the first two options
+and then in the next section consider the superior alternative of reparameterization.
 
+The default number of warmup iterations is 1000, but for models with
+highly varying posterior geometries, running more warmup iterations
+is often sufficient to find the correct step size.
 To reduce the step size of the algorithm, we want to lower the initial
 step size and increase the target acceptance rate.  The former keeps
 the step size low to start; the latter makes sure the adapted step
 size is lower.  So we'll run this again with the same seed, this time
-lowering the step size (<code>stepsize</code>) and increasing the
+running 2000 warmup iterations (<code>iter_warmup</code>),
+lowering the step size (<code>step_size</code>), and increasing the
 target acceptance rate (<code>adapt_delta</code>).
 
-```{r  comment=NA, results='hide'}
-fit_hier <- stan("hier.stan", data=c("N", "K", "y", "K_new", "y_new"),
-                 iter=(M / 2), chains=4,
-                 seed=1234, 
-                 control=list(stepsize=0.01, adapt_delta=0.99));
-ss_hier <- extract(fit_hier);
+```{r results='hide', comment=NA}
+fit_hier <- hier_model$sample(data=baseball_data,
+                              iter_sampling=2500,
+                              iter_warmup=2000,
+                              seed=1234,
+                              step_size=0.01,
+                              adapt_delta=0.95)
 ```
 
 Now it runs without divergent translations.
 
-Summary statistics for the posterior are printed as before.  
+```{r}
+fit_hier$cmdstan_diagnose()
+```
+
+Summary statistics for the posterior are printed as before.
 
 ```{r comment=NA}
-print(fit_hier, c("theta", "kappa", "phi"), probs=c(0.1, 0.5, 0.9));
+fit_hier$print(c("theta", "kappa", "phi"), max_rows=25)
 ```
 
 Because the Beta prior is conjugate to the binomial likelihood, the
@@ -611,10 +679,10 @@ observations (specifically $\phi \, \kappa - 1$ prior successes and
 $(1 - \phi) \, \kappa - 1$ prior failures).
 
 The parameter $\kappa$ is not well determined by the combination of
-data and Pareto prior, with a posterior 80% interval of roughly $(25,
-225)$.  By the informal discussion above, $\kappa \in (25, 225)$
+data and Pareto prior, with a posterior 90% interval of roughly $(20,
+364)$.  By the informal discussion above, $\kappa \in (20, 364)$
 ranges from weighting the data 2:1 relative to the prior to weighting
-it 1:5.  The wide posterior interval for $\kappa$ arises because the
+it 1:8.  The wide posterior interval for $\kappa$ arises because the
 exact variance in the population is not well constrained by only 18
 trials of size 45.  If there were more items (higher $N$) or even more
 trials per item (higher $K$), the posterior for $\kappa$ would be more
@@ -641,15 +709,19 @@ $\kappa \in (0, \infty)$ is transformed to $\log \kappa$.  We
 reproduce that figure here for our running example.
 
 ```{r}
+# extract model fit as R dataframe/ tibble for ggplot2
+hier_df = as_draws_df(fit_hier$draws())
+
 library(ggplot2);
 bda_plot <- function(df, x_lab, y_lab) {
   ggplot(df, aes(x=x, y=y)) +
     geom_point(shape=19, alpha=0.15) +
     xlab(x_lab) +
-    ylab(y_lab);
+    ylab(y_lab) +
+    theme_jupyter();
 }
 
-df_bda3_fig_5_3 <- with(ss_hier,
+df_bda3_fig_5_3 <- with(hier_df,
                         data.frame(x = log(phi / (1 - phi)),
                                    y = log(kappa)));
 plot_bda3_fig_5_3 <- 
@@ -672,13 +744,14 @@ the relation between $\kappa$ and the $\theta$.  For example, consider
 the following plot of $\theta_1$ vs. $\kappa$.
 
 ```{r}
+# note: must quote column names that look like indexed expr
 inv_logit <- function(u) { 1 / (1 + exp(-u)); }
-df_funnel <- with(ss_hier, 
-                  data.frame(x = inv_logit(theta[,1]), 
+df_funnel <- with(hier_df, 
+                  data.frame(x = inv_logit(hier_df$'theta[1]'), 
                              y = log(kappa)))
 plot_funnel <- 
   bda_plot(df_funnel, 
-           x_lab = expression(paste(logit(theta[1]))), 
+           x_lab = expression(paste(logit('theta[1]'))), 
            y_lab = expression(paste(log(kappa))));
 plot_funnel;
 ```
@@ -704,11 +777,11 @@ chance-of-success $\theta_n \in [0,1]$.  In this section, we consider
 an alternative parameterization in terms of the log-odds $\alpha_n$, which are
 defined by the logit transform as
 
-\[
+$
 \alpha_n 
 = \mathrm{logit}(\theta_n) 
 = \log \, \frac{\theta_n}{1 - \theta_n}.
-\]
+$
 
 For example, $\theta_n = 0.25$ corresponds to odds of $.25$ to $.75$
 (equivalently, $1$ to $3$), or log-odds of $\log .25 / .75 = -1.1$.
@@ -716,17 +789,17 @@ For example, $\theta_n = 0.25$ corresponds to odds of $.25$ to $.75$
 We will still use a binomial likelihood, only now we have logit as a
 so-called "link" function.
 
-\[
+$
 p(y_n \, | \, K_n, \alpha_n) 
 \ = \ \mathsf{Binomial}(y_n \, | \, K_n, \ \mathrm{logit}^{-1}(\alpha_n))
-\]
+$
 
 The inverse logit function is the logistic sigmoid from which logistic
 regression gets its name,
 
-\[
+$
 \mathrm{logit}^{-1}(\alpha_n) = \frac{1}{1 + \exp(-\alpha_n)} = \theta_n.
-\]
+$
 
 By construction, for any $\alpha_n \in (-\infty, \infty)$,
 $\mathrm{logit}^{-1}(\alpha_n) \in (0, 1)$; the sigmoid converts
@@ -737,24 +810,24 @@ practice, we only know the result will be in $[0, 1]$.
 Stan has a binomial probability function with a built-in logit link
 function, with which we can define the likelihood directly as
 
-\[
+$
 p(y_n \, | \, K_n, \alpha_n) 
 \ = \ \mathsf{BinomialLogit}(y_n \, | \, K_n, \alpha_n)
 \ = \ \mathsf{Binomial}(y_n \, | \, K_n, \ \mathrm{logit}^{-1}(\alpha_n)).
-\]
+$
 
 We use a simple normal hierarchical prior,
 
-\[
+$
 p(\alpha_n \, | \, \mu, \sigma)
 = \mathsf{Normal}(\alpha_n \, | \, \mu, \sigma).
-\]
+$
 
 Then one level up, we use a weakly informative hyperprior for $\mu$,
 
-\[
+$
 p(\mu) = \mathsf{Normal}(\mu \, | \, -1, 1),
-\]
+$
 
 which places 95% of the prior probability for $\mu$ in the interval
 $(-3, 1)$, which inverse-logit transforms to the interval $(0.05,
@@ -765,11 +838,11 @@ value should obviously be changed for other applications.
 The prior scale $\sigma > 0$ can be taken to be a truncated normal
 (half normal, here):
 
-\[
+$
 p(\sigma)
 \ = \ 2 \, \mathsf{Normal}(\sigma \, | \, 0, 1)
 \ \propto \ \mathsf{Normal}(\sigma \, | \, 0, 1).
-\]
+$
 
 This is a fairly broad prior in this case, being on the log-odds
 scale.
@@ -803,26 +876,28 @@ included in this document directly (code for the other models is in an
 appendix at the end of this document).
 
 
-```{r  comment=NA, results='hide'}
-fit_hier_logit_centered <- 
-  stan("hier-logit-centered.stan", data=c("N", "K", "y"),
-       iter=(M / 2), chains=4,
-       seed=1234);
-ss_hier_logit_centered <- extract(fit_hier_logit_centered);
+```{r results='hide', comment=NA}
+hier_logit_centered_model <- cmdstan_model(stan_file='hier-logit-centered.stan')
+fit_hier_logit_centered <- hier_logit_centered_model$sample(data=baseball_data, iter_sampling=2500, seed=1234)
+
 ```
 
 ```{r comment=NA}
-print(fit_hier_logit_centered, 
-      c("sigma", "theta[1]", "theta[10]", "alpha[1]", "alpha[10]",
-        "mu", "sigma", "lp__"), probs=c(0.1, 0.5, 0.9));
+fit_hier_logit_centered$print(c("theta[1]", "theta[10]","alpha[1]", "alpha[10]", "mu", "sigma", "lp__"))
 ```
 
-With the centered parameterization and Stan's defalt stepsize and
+With the centered parameterization and Stan's default stepsize and
 target acceptance rate, there are many divergent transitions.  Even
 with 10,000 posterior draws, the effective sample size for the
 population scale $\sigma$ is in the low hundreds, with $\hat{R} >
 1.01$.  These results might be usable, but the high $\hat{R}$ and low
 effective sample size are sure signs the chains aren't mixing well.
+
+A call to `cmdstan_diagnose` confirms this.
+
+```{r}
+fit_hier_logit_centered$cmdstan_diagnose()
+```
 
 *Warning:* In cases where the chains are not mixing well, Stan's
 effective sample size estimate will be much lower than that from
@@ -834,15 +909,18 @@ assume complete mixing in their effective sample size calculations and
 thus overestimate their performance when there is not good mixing.
 
 ```{r}
+hier_logit_centered_df = as_draws_df(fit_hier_logit_centered$draws());
+
 funnel_centered_df <-  
-  with(ss_hier_logit_centered,
-       data.frame(x = alpha[, 1],
+  with(hier_logit_centered_df,
+       data.frame(x = hier_logit_centered_df$'alpha[1]',
                   y = log(sigma)));
 funnel_centered <- 
   bda_plot(funnel_centered_df, 
-           x_lab = expression(paste("player 1 log odds of success ", alpha[1])), 
+           x_lab = expression(paste("player 1 log odds of success ", 'alpha[1]')),
            y_lab = expression(paste("log population scale ", log(sigma)))) + 
-  ggtitle("Centered Hierarchical Funnel Plot");
+  ggtitle("Centered Hierarchical Funnel Plot") +
+  theme_jupyter();
 funnel_centered;
 ```
 
@@ -869,31 +947,31 @@ random-walk Metropolis samplers (Papaspiliopoulos et al. 2003).  This
 basically amounts to changing the parameterization over which sampling
 is done, taking now a standard unit normal prior for a new variable,
 
-\[
+$
 \alpha^{\mathrm{std}}_n = \frac{\alpha_n - \mu}{\sigma}.
-\]
+$
 
 Then we can parameterize in terms of $\alpha^{\mathrm{std}}$, which
 has a standard-normal distribution
 
-\[
+$
 p(\alpha^{\mathrm{std}}_n) = \mathsf{Normal}(\alpha^{\mathrm{std}}_n \, | \, 0, 1).
-\]
+$
 
 We can then define our original $\alpha$ as a derived quantity
 
-\[
+$
 \alpha_n = \mu + \sigma \, \alpha^{\mathrm{std}}_n.
-\]
+$
 
 We code this implicitly in the Stan model by defining the
 likelihood as
 
-\[
+$
 p(y_n \, | \, \alpha^{\mathrm{std}}_n, \mu, \sigma, K)
 \ = \
 \mathsf{BinomialLogit}(K_n, \ \mu + \sigma \, \alpha_n).
-\]
+$
 
 This decouples the sampling distribution for $\alpha^{\mathrm{std}}$
 from $\mu$ and $\sigma$, greatly reducing their correlation in the
@@ -941,24 +1019,27 @@ The full Stan program for the hierarchical logistic model is in
 
 It is fit and the values are extracted as follows.
 
-```{r  comment=NA, results='hide'}
-fit_hier_logit <- stan("hier-logit.stan", data=c("N", "K", "y", "K_new", "y_new"),
-                       iter=(M / 2), chains=4,
-                       control=list(stepsize=0.01, adapt_delta=0.99));
-ss_hier_logit <- extract(fit_hier_logit);
+```{r results='hide', comment=NA}
+hier_logit_model <- cmdstan_model(stan_file='hier-logit.stan')
+fit_hier_logit <- hier_logit_model$sample(data=baseball_data,
+                                          iter_sampling=2500,
+                                          iter_warmup=2000,
+                                          seed=1234,
+                                          step_size=0.01,
+                                          adapt_delta=0.99);
 ```
 
 We can print as before.
 
 ```{r comment=NA}
-print(fit_hier_logit, c("alpha_std", "theta", "mu", "sigma"), probs=c(0.1, 0.5, 0.9));
+fit_hier_logit$print(c("alpha_std", "theta", "mu", "sigma"), max_rows=100)
 ```
 
 It is clear from the wide posteriors for the $\theta_n$ that there is
 considerable uncertainty in the estimates of chance-of-success on an
-item-by-item basis.  With an 80% interval of $(0.03, 0.32)$, it is
-clear that the data is consistent with complete pooling (i.e., $\sigma
-= 0$).
+item-by-item basis.  With an 90% interval of $(0.02, 0.37)$ for `sigma`,
+it is clear that the data is consistent with complete pooling
+(i.e., $\sigma = 0$).
 
 Compared to the direct beta priors with uniform and Pareto hyperpriors
 shown in the first example, the normal prior on log odds exerts more
@@ -966,15 +1047,16 @@ pull toward the population mean.  The posterior means for $\theta$ ranged from
 0.22 to 0.32 with the beta prior, but only range from 0.24 to 0.29 for
 the normal prior.  Furthermore, the posterior intervals for each
 values are shrunk compared to the beta prior.  For example, Roberto
-Clemente ($n = 1$), has an 80% central posterior interval of $(0.25,
-0.35)$ in the logistic model, whereas he had an 80% posterior interval
-of $(.26, .39)$ with a hierarchical beta prior.
+Clemente ($n = 1$), has an 90% central posterior interval of $(0.24,
+0.35)$ in the logistic model, whereas he had an 90% posterior interval
+of $(.25, .42)$ with a hierarchical beta prior.
 
 To consider how the reparameterization is working, we plot the
 posterior for the mean and log scale of the hyperprior.
 
 ```{r}
-df_bda3_fig_5_3_logit <- with(ss_hier_logit,
+hier_logit_df = as_draws_df(fit_hier_logit$draws());
+df_bda3_fig_5_3_logit <- with(hier_logit_df,
                               data.frame(x = mu,
                                          y = log(sigma)));
 plot_bda3_fig_5_3_logit <- 
@@ -988,18 +1070,18 @@ As before, we see that the prior location ($\mu$) and scale ($\sigma$) are coupl
 
 ```{r}
 df_bda3_fig_5_3_funnel <-  
-  with(ss_hier_logit,
-       data.frame(x = alpha_std[, 1],
+  with(hier_logit_df,
+       data.frame(x = hier_logit_df$'alpha_std[1]',
                   y = log(sigma)));
 plot_bda3_fig_5_3_funnel <-
   bda_plot(df_bda3_fig_5_3_funnel, 
-           x_lab = expression(paste("player 1 log odds (standardized), ", alpha[1])), 
+           x_lab = expression(paste("player 1 log odds (standardized), ", 'alpha_std[1]')),
            y_lab = expression(paste("log population scale, ", log(sigma)))) + 
   ggtitle("Non-Centered Hierarchical Funnel Plot");
 plot_bda3_fig_5_3_funnel;
 ```
 
-Compared to the earlier plot of $\log \kappa$ versus $\mathrm{logit}(\theta_1)$ in the direct hierarcical model on chance of success, there is much less of a dependency between the variables;  this can be seen because the variation is along the axes, not in a weak banana shape as in the first example.  But it still has the long-tail problem as $\sigma$ approaches zero (and $\log \sigma$ becomes more negative).
+Compared to the earlier plot of $\log \kappa$ versus $\mathrm{logit}(\theta_1)$ in the direct hierarchical model on chance of success, there is much less of a dependency between the variables;  this can be seen because the variation is along the axes, not in a weak banana shape as in the first example.  But it still has the long-tail problem as $\sigma$ approaches zero (and $\log \sigma$ becomes more negative).
 
 
 
@@ -1013,16 +1095,22 @@ intervals for the estimated chance-of-success parameters $\theta_n$ in
 the posterior.  The following R code reproduces a similar plot for our data.
 
 ```{r}
-ss_quantiles <- function(ss) {
-  apply(ss$theta, 2, quantile, probs = c(0.1, 0.5, 0.9));
+# summary statistics - quantiles 10%, 50%, 90%
+ss_quantiles <- function(draws_df) {
+  apply(select(draws_df, starts_with('theta')), 2, quantile, probs = c(0.1, 0.5, 0.9));
 }
-theta_pool <- ss_quantiles(ss_pool);
-theta_no_pool <- ss_quantiles(ss_no_pool);
-theta_hier <- ss_quantiles(ss_hier);
-theta_hier_logit <- ss_quantiles(ss_hier_logit);
+
+pool_df <- as_draws_df(fit_pool$draws());
+theta_pool <- ss_quantiles(pool_df);
+
+no_pool_df <- as_draws_df(fit_no_pool$draws());
+theta_no_pool <- ss_quantiles(no_pool_df);
+
+theta_hier <- ss_quantiles(hier_df);
+theta_hier_logit <- ss_quantiles(hier_logit_df);
 
 models <- c("complete pooling", "no pooling", "partial pooling", 
-            "partial pooling \n(log odds)")
+            "partial pooling, log odds")
 df_plot2 <- data.frame(x = rep(y / K, 4),
                        y = c(theta_pool["50%",], theta_no_pool["50%",],
                              theta_hier["50%",], theta_hier_logit["50%",]),
@@ -1035,7 +1123,7 @@ df_plot2 <- data.frame(x = rep(y / K, 4),
 pop_mean <- sum(y) / sum(K);
 plot_bda3_fig_5_4 <-
   ggplot(df_plot2, aes(x=x, y=y, ymin=ymin, ymax=ymax)) +
-  geom_hline(yintercept=pop_mean, colour="lightpink") +
+  geom_hline(yintercept=pop_mean, colour="orange") +
   geom_abline(intercept=0, slope=1, colour="skyblue") +
   facet_grid(. ~ model) +
   geom_errorbar(width=0.005, colour="gray60") +
@@ -1044,7 +1132,11 @@ plot_bda3_fig_5_4 <-
   scale_x_continuous(breaks = c(0.2, 0.3, 0.4)) +
   xlab(expression(paste("observed rate ", y[n] / K[n]))) +
   ylab(expression(paste("chance of success ", theta[n]))) +
-  ggtitle("Posterior Medians and 80% intervals\n(red line: population mean;  blue line: MLE)")
+  ggtitle("Posterior Medians and 80% intervals",
+         subtitle="orange line: population mean;  blue line: MLE") +
+  theme_jupyter();
+
+options(repr.plot.width=20, repr.plot.height=10)
 plot_bda3_fig_5_4;
 ```
 
@@ -1057,14 +1149,13 @@ are indistinguishable, any differences in estimates are due to MCMC
 error.
 
 The horizontal red line has an intercept equal to the overall success rate,
-
-\[
+$$
 \frac{\sum_{n=1}^N y_n}{\sum_{n=1}^N K_n}
 \ = \
 \frac{215}{810}
 \ = \ 
 0.266.
-\]
+$$
 
 The overall success rate is also the posterior mode (i.e., maximum
 likelihood estimate) for the complete pooling model.
@@ -1125,11 +1216,11 @@ of predictions weighted by the posterior.
 Given data $y$ and a model with parameters $\theta$, the posterior
 predictive distribution for new data $\tilde{y}$ is defined by
 
-\[
+$$
 p(\tilde{y} \, | \, y)
 \ = \
 \int_{\Theta} p(\tilde{y} \, | \, \theta) \ p(\theta \, | \, y) \ \mathrm{d}\theta,
-\]
+$$
 
 where $\Theta$ is the support of the parameters $\theta$.  What an
 integral of this form says is that $p(\tilde{y} \, | \, y)$ is defined
@@ -1146,14 +1237,14 @@ conditioned on $y$.
 Because the posterior predictive density is formulated as an
 expectation over the posterior, it is possible to compute via MCMC.
 With $M$ draws $\theta^{(m)}$ from the posterior $p(\theta \, | \,
-y)$, the posterior predicitve log density for new data
+y)$, the posterior predictive log density for new data
 $y^{\mathrm{new}}$ is given by
 
-\[
+$$
 p(y^{\mathrm{new}} \, | \, y)
 \ \approx \
 \log \frac{1}{M} \, \sum_{m=1}^M \ p\left( y^{\mathrm{new}} \, | \, \theta^{(m)} \right).
-\]
+$$
 
 In practice, this requires care to prevent underflow in floating point
 calculations; a robust calculation on the log scale is provided below.
@@ -1190,7 +1281,7 @@ estimated.
 
 #### Calibration
 
-A well calibrated statistical model is one in which the uncertainy in
+A well calibrated statistical model is one in which the uncertainty in
 the predictions matches the uncertainty in further data.  That is, if
 we estimate posterior 50% intervals for predictions on new data (here,
 number of hits in the rest of the season for each player), roughly 50%
@@ -1219,10 +1310,10 @@ variable $Y^{\mathrm{new}}_n$ denoting the number of further successes
 for item $n$ has a standard deviation from the repeated binary trials
 of
 
-\[
+$$
 \mathrm{sd}[Y^{\mathrm{new}}_n] \ = \ \sqrt{K \
 \theta \, (1 - \theta)}.
-\]
+$$
 
 
 #### Why Evaluate with the Predictive Posterior?
@@ -1241,24 +1332,24 @@ intervals (Gneiting et al. 2007).
 
 #### Computing the Log Predictive Posterior Density
 
-The log of posterior predicitve density is defined in the obvious way as
+The log of posterior predictive density is defined in the obvious way as
 
-\[
+$
 \log p(\tilde{y} \, | \, y)
 = \log \int_{\Theta} p(\tilde{y} \, | \, \theta) 
                      \ p(\theta \, | \, y)
                      \ \mathrm{d}\theta.
-\]
+$
 
 This is not a posterior expectation, but rather the log of a posterior
 expectation.  In particular, it should not be confused with the
 posterior expectation of the log predictive density, which is given by
 
-\[
+$
  \int_{\Theta} \left( \log p(\tilde{y} \, | \, \theta) \right) 
                \ p(\theta \, | \, y)  
                \ \mathrm{d}\theta.
-\]
+$
 
 Although this is easy to compute in Stan in a stable fashion, it does
 not produce the same answer (as we show below).
@@ -1268,11 +1359,11 @@ inequality](https://en.wikipedia.org/wiki/Jensen%27s_inequality) shows
 that the expectation of the log is less than or equal to the log of
 the expectation,
 
-\[
+$
 \log \int_{\Theta} p(\tilde{y} \, | \, \theta) \ p(\theta \, | \, y) \ \mathrm{d}\theta
 \ \leq \
 \int_{\Theta} \left( \, \log p(\tilde{y} \, | \, \theta) \, \right) \ p(\theta \, | \, y) \ \mathrm{d}\theta.
-\]
+$
 
 We'll compute both expectations and demonstrate Jensen's inequality in
 our running example.
@@ -1299,24 +1390,23 @@ generated quantities {
 
 The posterior mean for <code>log_p_new</code> will give us
 
-\[
+$
  \int_{\Theta} \left( \log p(\tilde{y} \, | \, \theta) \right) 
                \ p(\theta \, | \, y)  
                \ \mathrm{d}\theta
 \ \approx \
 \frac{1}{M} \, \sum_{m=1}^M \log p(y^{\mathrm{new}} \, | \, \theta^{(m)}).
-\]
+$
 
 This calculation is included in all four of the models we have
 previously fit and can be displayed directly as follows as the
 posterior mean of `log_p_new`.
 
 ```{r comment=NA}
-print(sprintf("%10s  %16s", "MODEL", "VALUE"), quote = FALSE);
-print(sprintf("%10s  %16.0f", "pool", mean(ss_pool$log_p_new)), quote=FALSE);
-print(sprintf("%10s  %16.0f", "no pool", mean(ss_no_pool$log_p_new)), quote=FALSE);
-print(sprintf("%10s  %16.0f", "hier", mean(ss_hier$log_p_new)), quote=FALSE);
-print(sprintf("%10s  %16.0f", "hier logit", mean(ss_hier_logit$log_p_new)), quote=FALSE);
+message(sprintf("%25s  %5.1f", "complete pooling", mean(pool_df$log_p_new)));
+message(sprintf("%25s  %5.1f", "no pooling", mean(no_pool_df$log_p_new)));
+message(sprintf("%25s  %5.1f", "partial pooling", mean(hier_df$log_p_new)));
+message(sprintf("%25s  %5.1f", "partial pooling, log odds", mean(hier_logit_df$log_p_new)));
 ```
 
 From a predictive standpoint, the models are ranked by the amount of
@@ -1332,11 +1422,11 @@ The straight path to calculate this would be to define a generated
 quantity $p(y^{\mathrm{new}} \, | y)$, look at the posterior mean
 computed by Stan, and takes its log.   That is, 
 
-\[
+$
 \log p(y^{\mathrm{new}} \, | \, y)
 \ \approx \
 \log \frac{1}{M} \, \sum_{m=1}^M p(y^{\mathrm{new}} \, | \, \theta^{(m)}).
-\]
+$
 
 Unfortunately, this won't work in most cases because when we try to
 compute $p(y^{\mathrm{new}} \, | \, \theta^{(m)})$ directly, it is prone
@@ -1356,32 +1446,32 @@ To avoid underflow, we're going to use the
 [log-sum-of-exponentials](https://en.wikipedia.org/wiki/LogSumExp)
 trick, which begins by noting the obvious,
 
-\[
+$
 \log \frac{1}{M} \, \sum_{m=1}^M \ p(y^{\mathrm{new}} \, | \, \theta^{(m)}).
 \ = \
 \log \frac{1}{M} \, \sum_{m=1}^M
                      \ \exp \left( \log p(y^{\mathrm{new}} \, | \, \theta^{(m)}) \right).
-\]
+$
 
 We'll then write that last expression as
 
-\[
+$
 -\log M 
 +  \mathrm{log\_sum\_exp \, }_{m=1}^M
         \ \log p(y^{\mathrm{new}} \, | \, \theta^{(m)})
-\]
+$
 
 We can compute $\mathrm{log\_sum\_exp}$ stably by subtracting the max value.
 Suppose $u = u_1, \ldots, u_M$, and $\max(u)$ is the largest $u_m$.
 We can calculate
 
-\[
+$
 \mathrm{log\_sum\_exp \, }_{m=1}^M \ u_m
 \ = \
 \log \sum_{m=1}^M \exp(u_m)
 \ = \
 \max(u) + \log \sum_{m=1}^M \exp(u_m - \max(u)).
-\]
+$
 
 Because $u_m - \max(u) \leq 0$, the exponentiations cannot overflow.
 They may underflow to zero, but this will not lose precision because
@@ -1407,15 +1497,15 @@ and then use it to print the log posterior predictive densities for
 our fit.
 
 ```{r comment=NA}
-print_new_lp <- function(name, ss) {  
-  lp <- -log(M) + log_sum_exp(ss$log_p_new);
-  print(sprintf("%25s  %5.1f", name,  lp), quote=FALSE);
+print_new_lp <- function(name, df) {  
+  lp <- -log(nrow(df)) + log_sum_exp(df$log_p_new);
+  message(sprintf("%25s  %5.1f", name,  lp));
 }
 
-print_new_lp("complete pooling", ss_pool); 
-print_new_lp("no pooling", ss_no_pool); 
-print_new_lp("partial pooling", ss_hier); 
-print_new_lp("partial pooling (logit)", ss_hier_logit); 
+print_new_lp("complete pooling", pool_df); 
+print_new_lp("no pooling", no_pool_df); 
+print_new_lp("partial pooling", hier_df); 
+print_new_lp("partial pooling (logit)", hier_logit_df); 
 ```
 
 Now the ranking is different!  As expected, the values here are lower
@@ -1473,18 +1563,18 @@ The number of remaining at-bats $K^{\mathrm{new}}$ was printed out in
 the original table along with the actual number of hits.
 
 ```{r comment=NA}
-print(fit_pool, c("z"), probs=c(0.1, 0.5, 0.9), digits=0);
+fit_pool$print('z', max_rows=18)
 ```
 
 Translating the posterior number of hits into a season batting
 average, $\frac{y_n + z_n}{K_n + K^{\mathrm{new}}_n}$,
 we get an 80% posterior interval of
 
-\[
+$$
 \left( \frac{18 + 93}{45 + 367}, \frac{18 + 147}{45 + 367} \right) 
 \ = \
 (0.269, 0.400).
-\]
+$$
 
 for Roberto Clemente in the basic hierarchical model.  Part of our
 uncertainty here is due to our uncertainty in Clemente's underlying
@@ -1511,6 +1601,7 @@ in his remaining at bats (trials); the observed success rate in the
 remainder of the season is shown as a blue dot.
 
 ```{r comment=NA}
+# N is number of players
 y_new_25_pool <- c(NA, N);
 y_new_25_no_pool <- c(NA, N);
 y_new_25_hier <- c(NA, N);
@@ -1519,16 +1610,24 @@ y_new_75_pool <- c(NA, N);
 y_new_75_no_pool <- c(NA, N);
 y_new_75_hier <- c(NA, N);
 y_new_75_hier_logit <- c(NA, N);
+
+
+zs_pool <- matrix(fit_pool$draws('z'), M, N);
+zs_no_pool <- matrix(fit_no_pool$draws('z'), M, N);
+zs_hier <- matrix(fit_hier$draws('z'), M, N);
+zs_hier_logit <- matrix(fit_hier_logit$draws('z'), M, N);
+
 for (n in 1:N) {
-  y_new_25_pool[n] <- quantile(ss_pool$z[,n], 0.25)[[1]];
-  y_new_25_no_pool[n] <- quantile(ss_no_pool$z[,n], 0.25)[[1]];
-  y_new_25_hier[n] <- quantile(ss_hier$z[,n], 0.25)[[1]];
-  y_new_25_hier_logit[n] <- quantile(ss_hier_logit$z[,n], 0.25)[[1]];
-  y_new_75_pool[n] <- quantile(ss_pool$z[,n], 0.75)[[1]];
-  y_new_75_no_pool[n] <- quantile(ss_no_pool$z[,n], 0.75)[[1]];
-  y_new_75_hier[n] <- quantile(ss_hier$z[,n], 0.75)[[1]];
-  y_new_75_hier_logit[n] <- quantile(ss_hier_logit$z[,n], 0.75)[[1]];
+  y_new_25_pool[n] <- quantile(zs_pool[, n], 0.25)[[1]];
+  y_new_25_no_pool[n] <- quantile(zs_no_pool[, n], 0.25)[[1]];
+  y_new_25_hier[n] <- quantile(zs_hier[, n], 0.25)[[1]];
+  y_new_25_hier_logit[n] <- quantile(zs_hier_logit[, n], 0.25)[[1]];
+  y_new_75_pool[n] <- quantile(zs_pool[, n], 0.75)[[1]];
+  y_new_75_no_pool[n] <- quantile(zs_no_pool[, n], 0.75)[[1]];
+  y_new_75_hier[n] <- quantile(zs_hier[, n], 0.75)[[1]];
+  y_new_75_hier_logit[n] <- quantile(zs_hier_logit[, n], 0.75)[[1]];    
 }
+
 y_new_25_pool <- y_new_25_pool / K_new;
 y_new_25_no_pool <- y_new_25_no_pool / K_new;
 y_new_25_hier <- y_new_25_hier / K_new;
@@ -1543,7 +1642,7 @@ df_post_pred <- data.frame(x = rep(1:N, 4),
                            model = c(rep("complete pooling", N),
                                      rep("no pooling", N),
                                      rep("partial pooling", N),
-                                     rep("partial pooling (log odds)", N)));
+                                     rep("partial pooling, log odds", N)));
 plot_post_pred <-
   ggplot(df_post_pred, aes(x=x, y=y)) +
   geom_point(colour="darkblue", size=1) +
@@ -1556,9 +1655,9 @@ plot_post_pred <-
   scale_x_continuous(breaks=c()) + 
   xlab("player ID") + 
   ylab("batting average") +
-  ggtitle(expression(
-    atop("Posterior Predictions for Batting Average in Remainder of Season",
-         atop("50% posterior predictive intervals (gray bars); observed (blue dots)", ""))));
+  ggtitle("Posterior Predictions for Batting Average in Remainder of Season",
+          subtitle="50% posterior predictive intervals (gray bars); observed (blue dots)") +
+  theme_jupyter();
 plot_post_pred;
 ```
 
@@ -1648,7 +1747,7 @@ over parameters and data. For example, the probability of player $n$'s
 batting average being 0.400 or better conditioned on the data $y$ is
 defined by the conditional event probability
 
-\[
+$
 \mathrm{Pr}\left[
 \frac{(y_n + z_n)}{(45 + K^{\mathrm{new}}_n)} \geq 0.400 
 \, \Big| \, 
@@ -1660,19 +1759,19 @@ y
        \ p(z_n \, | \, \theta_n, K^{\mathrm{new}}_n)
        \ p(\theta \, | \, y, K)
        \ \mathrm{d}\theta.
-\]
+$
 
 The indicator function $\mathrm{I}[c]$ evaluates to 1 if the condition
 $c$ is true and 0 if it is false.  Because it is just another
 expectation with respect to the posterior, we can calculate this event
 probability using MCMC as
 
-\[
+$
 \mathrm{Pr}\left[\frac{(y_n + z_n)}{(45 + K^{\mathrm{new}}_n)} \geq
 0.400 \, \Big| \, y \right]
 \ \approx \
 \frac{1}{M} \, \sum_{m=1}^M \mathrm{I}\left[\frac{(y_n + z_n^{(m)})}{(45 + K^{\mathrm{new}}_n)} \geq 0.400\right].
-\]
+$
 
 This event is about the season batting average being greater than
 0.400.  What if we care about ability (chance of success), not batting
@@ -1681,7 +1780,7 @@ the question of whether $\mathrm{Pr}[\theta_n > 0.4]$.  This is
 defined as a weighted average over the prior and computed via MCMC as
 the previous case.
 
-\[
+$
 \mathrm{Pr}\left[\theta_n \geq 0.400 \, | \, y \right]
 \ = \
 \int_{\Theta}
@@ -1690,7 +1789,7 @@ the previous case.
        \ \mathrm{d}\theta
 \ \approx \
 \frac{1}{M} \, \sum_{m=1}^M \mathrm{I}[\theta_n^{(m)} \geq 0.400].
-\]
+$
 
 In Stan, we just declare and define the indicators directly in the
 generated quantities block.
@@ -1722,23 +1821,32 @@ summary.  We can summarize for all four models again.  Only the event
 indicator variables are printed---the parameter estimates will be the
 same as before.
 
-```{r comment=NA}
-pars_to_print <- c("some_ability_gt_350", 
-    "avg_gt_400[1]","avg_gt_400[5]", "avg_gt_400[10]", 
-    "ability_gt_400[1]", "ability_gt_400[5]", "ability_gt_400[10]");
-print(fit_pool, pars=pars_to_print, probs=c());
-print(fit_no_pool, pars=pars_to_print, probs=c());
-print(fit_hier, pars=pars_to_print, probs=c());
-print(fit_hier_logit, pars=pars_to_print, probs=c());
-```
-
-The standard deviation and quantiles are not useful here and the
-quantiles are suppressed through an empty <code>probs</code> argument
-to <code>print()</code>; we do want to see a reasonable effective
+The standard deviation and quantiles are not useful here;
+we do want to see a reasonable effective
 sample size estimate and no evidence of non-convergence in the form
 for $\hat{R}$ values much greater than 1.  The NaN values in the
 $\hat{R}$ column arise when every posterior draw is the same; there is
 zero sample variance, and so $\hat{R}$ is not defined.
+
+```{r comment=NA}
+# players of interest
+message(c(names[1], "\n", names[5], "\n", names[10]));
+```
+
+```{r comment=NA}
+pars_to_print <- c("some_ability_gt_350", 
+    "avg_gt_400[1]","avg_gt_400[5]", "avg_gt_400[10]", 
+    "ability_gt_400[1]", "ability_gt_400[5]", "ability_gt_400[10]");
+
+message("complete pooling (note: all players have estimated ability 0.27)");
+fit_pool$print(pars_to_print);
+message("no pooling");
+fit_no_pool$print(pars_to_print);
+message("partial pooling");
+fit_hier$print(pars_to_print);
+message("partial pooling, log odds");
+fit_hier_logit$print(pars_to_print);
+```
 
 These results show that the probability of batting 0.400 or better for
 the season is a different question than asking if the player's ability
@@ -1804,11 +1912,11 @@ The generated quantity <code>some_ability_gt_350</code> will be set to
 And thus the posterior mean of this generated quantity will be the
 event probability
 
-\[
+$$
 \mathrm{Pr}[\mathrm{max}(\theta) > 0.350]
 \ = \ \int_{\Theta} \mathrm{I}[\mathrm{max}(\theta) > 0.35] \ p(\theta \, | \, y, K) \ \mathrm{d}\theta
 \ \approx \ \frac{1}{M} \, \sum_{m=1}^M \ \mathrm{I}[\mathrm{max}(\theta^{(m)}) > 0.35]
-\]
+$$
 
 where $\theta^{(m)}$ is the sequence of posterior draws for the
 ability parameter vector.  Stan reports this value as the posterior
@@ -1873,7 +1981,7 @@ pooling model, where every player is assumed to have the same ability.
 We can print just the ranks and the 80% central interval for the basic pooling model.
 
 ```{r comment=NA}
-print(fit_hier, "rnk", probs=c(0.1, 0.5, 0.9));
+fit_hier$print("rnk", max_rows=18);
 ```
 
 It is again abundantly clear from the posterior intervals that our
@@ -1887,12 +1995,14 @@ the baseball data.
 
 ```{r comment=NA}
 library(ggplot2);
+rnk_hier <- matrix(fit_hier$draws('rnk'), M, N);
 df_rank <- data.frame(list(name = rep(as.character(df[[1,2]]), M),
-                           rank = ss_hier$rnk[, 1]));
+                           rank = rnk_hier[, 1]));
+
 for (n in 2:N) {
   df_rank <- rbind(df_rank,
                    data.frame(list(name = rep(as.character(df[[n,2]]), M),
-                              rank = ss_hier$rnk[, n])));
+                              rank = rnk_hier[, n])));
 }
 rank_plot <-
   ggplot(df_rank, aes(rank)) +
@@ -1901,7 +2011,9 @@ rank_plot <-
   scale_x_discrete(limits=c(1, 5, 10, 15)) +
   scale_y_discrete(name="posterior probability", breaks=c(0, 0.1 * M, 0.2 * M),
                    labels=c("0.0", "0.1", "0.2")) + 
-  ggtitle("Rankings for Partial Pooling Model");
+  ggtitle("Rankings for Partial Pooling Model") +
+  theme_jupyter();
+options(repr.plot.width=20, repr.plot.height=16)
 rank_plot;
 ```
 
@@ -1916,7 +2028,7 @@ We can use our ranking statistic to calculate the event probability
 for item $n$ that the item has the highest chance of success using
 MCMC as
 
-\[
+$$
 \mathrm{Pr}[\theta_n = \max(\theta)]
 \ = \
 \int_{\Theta} \mathrm{I}[\theta_n = \mathrm{max}(\theta)]
@@ -1924,7 +2036,7 @@ MCMC as
               \ \mathrm{d}\theta
 \ \approx \ 
 \frac{1}{M} \, \sum_{m=1}^M \mathrm{I}[\theta^{(m)}_n = \mathrm{max}(\theta^{(m)})].
-\]
+$$
 
 Like our other models, the partial pooling mitigates the implicit
 multiple comparisons being done to calculate the probabilities of
@@ -1964,17 +2076,21 @@ probability.
 We can then plot the results for the four models.
 
 ```{r comment=NA}
-df_is_best_for <- function(name, ss) {
+df_is_best_for <- function(name, draws) {
   is_best <- rep(NA, N);
   for (n in 1:N) {
-    is_best[n] <- mean(ss$is_best[,n]);
+    is_best[n] <- mean(draws[,n]);
   }
   return(data.frame(list(item=1:N, is_best=is_best, model=name)));
 }
 
-df_is_best <-  rbind(df_is_best_for("no pool", ss_no_pool),
-                     df_is_best_for("hier", ss_hier),
-                     df_is_best_for("hier (log odds)", ss_hier_logit));
+best_no_pool <- matrix(fit_no_pool$draws('is_best'), M, N);
+best_hier <- matrix(fit_hier$draws('is_best'), M, N);
+best_hier_logit <- matrix(fit_hier_logit$draws('is_best'), M, N);
+
+df_is_best <-  rbind(df_is_best_for("no pooling", best_no_pool),
+                     df_is_best_for("partial pooling", best_hier),
+                     df_is_best_for("partial pooling, log odds", best_hier_logit));
 
 is_best_plot <-
   ggplot(df_is_best, aes(x=item, y=is_best)) +
@@ -1982,7 +2098,9 @@ is_best_plot <-
   facet_wrap(~ model) +
   scale_y_continuous(name = "Pr[player is best]") +
   scale_x_discrete(name="player", breaks=c(1, 5, 10, 15)) +
-  ggtitle("Who is the Best Player?");
+  ggtitle("Who is the Best Player?") +
+  theme_jupyter();
+options(repr.plot.width=12, repr.plot.height=4)
 is_best_plot;
 ```
 
@@ -2031,9 +2149,9 @@ sample standard deviation.
 Given a test statistic $T$ and data $y$, the Bayesian $p$-value has a
 direct definition as a probability,
 
-\[
+$$
 p_B = \mathrm{Pr}[T(y^{\mathrm{rep}}) \geq T(y) \, | \, y].
-\]
+$$
 
 Bayesian $p$-values, like their traditional counterparts, are
 probabilities, but not probabilities that a model is true.  They
@@ -2045,11 +2163,11 @@ used to estimate the model is unlikely to have been generated by the
 estimated model.  As with other forms of full Bayesian inference, our
 estimate is the full posterior, not just a point estimate.
 
-As with other Bayesain inferences, we average over the posterior
+As with other Bayesian inferences, we average over the posterior
 rather than working from a point estimate of the parameters.
 Expanding this as an expectation of an indicator function,
 
-\[
+$$
 p_B 
 \ = \ 
   \int_{\Theta, Y^{\mathrm{rep}}} 
@@ -2057,7 +2175,7 @@ p_B
     \ p(y^{\mathrm{rep}} \, | \, \theta)
     \ p(\theta \, | \, y)
     \ \mathrm{d}\theta,
-\]
+$$
 
 We treat $y^{\mathrm{rep}}$ as a parameter in parallel with $\theta$,
 integrating over possible values $y^{\mathrm{rep}} \in
@@ -2065,20 +2183,20 @@ Y^{\mathrm{rep}}$.  As usual, we use the integration sign in a general
 way intended to include summation, as with the discrete variable
 $y^{\mathrm{rep}}$.
 
-The formualation as an expectation leads to the obvious MCMC
+The formulation as an expectation leads to the obvious MCMC
 calculation based on posterior draws $y^{\mathrm{rep} (m)}$ for
 $m \in 1{:}M$,
 
-\[
+$$
 p_B
 \approx 
 \frac{1}{M}
 \,
 \sum_{m=1}^M
 \mathrm{I}[T(y^{\mathrm{rep} \ (m)}) \geq T(y)].
-\]
+$$
 
-
+<!-- #region -->
 In Stan, the test statistics are first defined for the observed data.
 Because they are functions purely of variables defined in the data
 block, they can be defined in the transformed data block so that they
@@ -2088,15 +2206,10 @@ all possible.
 
 ```
 transformed data {
-  real min_y;   // minimum successes
-  real max_y;   // maximum successes
-  real mean_y;  // sample mean successes
-  real sd_y;    // sample std dev successes
-
-  min_y <- min(y);
-  max_y <- max(y);
-  mean_y <- mean(to_vector(y));
-  sd_y <- sd(to_vector(y));
+  real min_y = min(y);   // minimum successes
+  real max_y = max(y);   // maximum successes
+  real mean_y = mean(to_vector(y));  // sample mean successes
+  real sd_y = sd(to_vector(y));    // sample std dev successes
 }
 ```
 
@@ -2106,34 +2219,13 @@ quantities block.
 ```
 generated quantities {
   ...
-  int<lower=0> y_rep[N];      // replications for existing items
-  ...
-  for (n in 1:N)
-    y_rep[n] <- binomial_rng(K[n], theta[n]);
+  array[N] int<lower=0> y_rep = binomial_rng(K, theta);
   ...
 }
 ```
 
-Then the test statistics are defined in the generated quantities
-block.
-
-```
-generated quantities {
-  ...
-  real<lower=0> min_y_rep;   // posterior predictive min replicated successes
-  real<lower=0> max_y_rep;   // posterior predictive max replicated successes
-  real<lower=0> mean_y_rep;  // posterior predictive sample mean replicated successes
-  real<lower=0> sd_y_rep;    // posterior predictive sample std dev replicated successes
-  ...
-  min_y_rep <- min(y_rep);
-  max_y_rep <- max(y_rep);
-  mean_y_rep <- mean(to_vector(y_rep));
-  sd_y_rep <- sd(to_vector(y_rep));
-  ...
-}
-```
-
-Finally, the actual $p$-value indicators are computed and assigned to
+Then the posterior predictive test statistics are defined in the generated quantities
+block and the actual $p$-value indicators are computed and assigned to
 integer values.  The calls to <code>to_vector()</code> convert an
 array of integers to an array of real values so that they are
 appropriately typed to be the input to the standard deviation
@@ -2142,27 +2234,36 @@ calculation.
 ```
 generated quantities {
   ...
-  int<lower=0, upper=1> p_min;  // posterior predictive p-values
-  int<lower=0, upper=1> p_max;
-  int<lower=0, upper=1> p_mean;
-  int<lower=0, upper=1> p_sd;
-  ...
-  p_min <- (min_y_rep >= min_y);
-  p_max <- (max_y_rep >= max_y);
-  p_mean <- (mean_y_rep >= mean_y);
-  p_sd <- (sd_y_rep >= sd_y);
-  ...
+  real<lower=0> min_y_rep = min(y_rep);
+  int<lower=0, upper=1> p_min = min_y_rep >= min_y;
+
+  real<lower=0> max_y_rep = max(y_rep);
+  int<lower=0, upper=1> p_max = max_y_rep >= max_y;
+  
+  real<lower=0> mean_y_rep = mean(to_vector(y_rep));
+  int<lower=0, upper=1> p_mean = mean_y_rep >= mean_y;
+
+  real<lower=0> sd_y_rep = sd(to_vector(y_rep));
+  int<lower=0, upper=1> p_sd = sd_y_rep >= sd_y;
 }
 ```
 
+
 The fit from the Stan program can then be used to display the Bayesian
 $p$-values for each of the models.
+<!-- #endregion -->
 
 ```{r comment=NA}
-print(fit_pool, c("p_min", "p_max", "p_mean", "p_sd"), probs=c());
-print(fit_no_pool, c("p_min", "p_max", "p_mean", "p_sd"), probs=c());
-print(fit_hier, c("p_min", "p_max", "p_mean", "p_sd"), probs=c());
-print(fit_hier_logit, c("p_min", "p_max", "p_mean", "p_sd"), probs=c());
+pars_to_print <- c("p_min", "p_max", "p_mean", "p_sd");
+
+message("complete pooling");
+fit_pool$print(pars_to_print);
+message("no pooling");
+fit_no_pool$print(pars_to_print);
+message("partial pooling");
+fit_hier$print(pars_to_print);
+message("partial pooling, log odds");
+fit_hier_logit$print(pars_to_print);
 ```
 
 The only worrisomely extreme value is the $p$-value for standard
@@ -2191,23 +2292,23 @@ pvals_frame <- function(ss, model_name) {
                                   replication = ss$max_y_rep),
                                   model = rep(model_name, M));
   df_pvals_mean <- data.frame(list(test_stat = rep("mean", M), 
-                                   replication = ss$mean_y_rep),	
-				   model = rep(model_name, M));
+                                   replication = ss$mean_y_rep),
+                                   model = rep(model_name, M));
   df_pvals_sd <- data.frame(list(test_stat = rep("sd", M), 
                                  replication = ss$sd_y_rep),
                                  model = rep(model_name, M));
   return(rbind(df_pvals_min, df_pvals_max, df_pvals_mean, df_pvals_sd));
 }
 
-df_pvals <- rbind(pvals_frame(ss_hier, "partial pool"),
-                  pvals_frame(ss_hier_logit, "partial (logit)"),
-                  pvals_frame(ss_pool, "complete pool"),
-                  pvals_frame(ss_no_pool, "no pool"));
+df_pvals <- rbind(pvals_frame(hier_df, "partial pooling"),
+                  pvals_frame(hier_logit_df, "partial pooling, log odds"),
+                  pvals_frame(pool_df, "complete pooling"),
+                  pvals_frame(no_pool_df, "no pooling"));
 
 post_test_stat_plot <-
   ggplot(df_pvals, aes(replication)) +
   facet_grid(model ~ test_stat) +
-  geom_histogram(binwidth = 0.5, colour="black", size = 0.25, fill="white") + 
+  geom_histogram(binwidth = 0.5, colour="black", size = 0.5, fill="darkgrey") + 
   theme(axis.title.y = element_blank(),
         axis.text.y = element_blank(),
         axis.ticks.y = element_blank()) +
@@ -2217,8 +2318,10 @@ post_test_stat_plot <-
                                              rep(y_mean, M), rep(y_sd, M)), 4),
                                test_stat = df_pvals$test_stat,
                                replication = df_pvals$replication),
-             colour = "blue", size = 0.25) +
-  ggtitle("Posterior p-values")
+             colour = "blue", size = 0.5) +
+  ggtitle("Posterior p-values") +
+  theme_jupyter();
+options(repr.plot.width=16, repr.plot.height=16)
 post_test_stat_plot;
 ```
 
@@ -2285,8 +2388,10 @@ We can now print the replicated values <code>y_rep</code> in both the
 hierarchical and hierarchical logit models.
 
 ```{r comment=NA}
-print(fit_hier, c("y_rep", "y_pop_rep[1]"), probs=c(0.1, 0.5, 0.9));
-print(fit_hier_logit, c("y_rep", "y_pop_rep[1]"), probs=c(0.1, 0.5, 0.9));
+message("partial pooling");
+fit_hier$print(c("y_rep", "y_pop_rep[1]"), max_rows=18);
+message("partial pooling, log odds");
+fit_hier_logit$print(c("y_rep", "y_pop_rep[1]"), max_rows=18);
 ```
 
 The variable <code>y_rep</code> is ordered because it's based on the
@@ -2305,10 +2410,12 @@ fifteen for display.
 ```{r comment=NA}
 df_post <- data.frame(list(dataset = rep("REAL", N),
                            y = y));
+y_rep_hier_logit <- matrix(fit_hier_logit$draws('y_rep'), M, N);
+
 for (n in 1:15) {
   df_post <- rbind(df_post,
                    data.frame(list(dataset = rep(paste("repl ", n), N),
-                                   y = ss_hier_logit$y_rep[n,])));
+                                   y = y_rep_hier_logit[n,])));
 }
 post_plot <-
   ggplot(df_post, aes(y)) +
@@ -2322,13 +2429,16 @@ post_plot;
 
 And now we can do the same thing for the population-level replication; because the code's the same, we do not echo it to the output.
 
-```{r comment=NA, echo=FALSE}
+```{r comment=NA}
 df_pop_post <- data.frame(list(dataset = rep("REAL", N),
                                y = y));
+
+y_pop_rep_hier_logit <- matrix(fit_hier_logit$draws('y_pop_rep'), M, N);
+
 for (n in 1:15) {
   df_pop_post <- rbind(df_pop_post,
                        data.frame(list(dataset = rep(paste("repl ", n), N),
-                                        y = ss_hier_logit$y_pop_rep[n,])));
+                                        y = y_pop_rep_hier_logit[n,])));
 }
 post_pop_plot <-
   ggplot(df_pop_post, aes(y)) +
@@ -2357,13 +2467,14 @@ bats."
 
 Here are the same plots for the basic hierarchical model.  This time we suppress printing the ggplot code, which is the same as before, and just show the graphs.
 
-```{r comment=NA, echo=FALSE}
+```{r echo=FALSE, comment=NA}
 df_post_beta <- data.frame(list(dataset = rep("REAL", N),
                                 y = y));
+y_rep_hier <- matrix(fit_hier$draws('y_rep'), M, N);
 for (n in 1:15) {
   df_post_beta <- rbind(df_post_beta,
                         data.frame(list(dataset = rep(paste("repl ", n), N),
-                                        y = ss_hier$y_rep[n,])));
+                                        y = y_rep_hier[n,])));
 }
 post_plot_beta <-
   ggplot(df_post_beta, aes(y)) +
@@ -2375,13 +2486,14 @@ post_plot_beta <-
 post_plot_beta;
 ```
 
-```{r comment=NA, echo=FALSE}
+```{r echo=FALSE, comment=NA}
 df_pop_post_beta <- data.frame(list(dataset = rep("REAL", N),
                                y = y));
+y_pop_rep_hier <- matrix(fit_hier$draws('y_pop_rep'), M, N);
 for (n in 1:15) {
   df_pop_post_beta <- rbind(df_pop_post_beta,
                             data.frame(list(dataset = rep(paste("repl ", n), N),
-                                             y = ss_hier$y_pop_rep[n,])));
+                                             y = y_pop_rep_hier[n,])));
 }
 post_pop_plot_beta <-
   ggplot(df_pop_post_beta, aes(y)) +
@@ -2415,7 +2527,7 @@ matched hyperpriors; see the exercises).  With very little data, there
 is very little we can do to gain sharp inferences other than provide
 more informative priors, which is well worth doing when prior
 information is available.  On the other hand, with more data, the
-models provide similar results (see the exericses), and in the limit,
+models provide similar results (see the exercises), and in the limit,
 all of the models (other than complete pooling) converge to
 posteriors that are delta functions around the empirical chance of
 success (i.e., the maximum likelihood estimate).  Meanwhile, 
@@ -2534,7 +2646,7 @@ contrast to the basic partial pooling model.
 our model fit to data using Bayesian $p$-Values$?  Code some up and
 evaluate on one of the data sets given here or on simulated data.
 
-1.  Discuss why the lack of an alternative hypotehsis makes it
+1.  Discuss why the lack of an alternative hypothesis makes it
 impossible to perform power calculations with Bayesian $p$-values.
 What are the implications for hypothesis testing for model fit?
 
@@ -2683,7 +2795,7 @@ Major League Baseball.  The data was originally downloaded from the
 
 ####  <code>pool.stan</code>
 
-```{r comment=NA, echo=FALSE, comment=NA}
+```{r echo=FALSE, comment=NA}
 file_path <- "pool.stan";
 lines <- readLines(file_path, encoding="ASCII");
 for (n in 1:length(lines)) cat(lines[n],'\n');
@@ -2691,7 +2803,7 @@ for (n in 1:length(lines)) cat(lines[n],'\n');
 
 #### <code>no-pool.stan</code>
 
-```{r comment=NA, echo=FALSE}
+```{r echo=FALSE, comment=NA}
 file_path <- "no-pool.stan";
 lines <- readLines(file_path, encoding="ASCII");
 for (n in 1:length(lines)) cat(lines[n],'\n');
@@ -2700,7 +2812,7 @@ for (n in 1:length(lines)) cat(lines[n],'\n');
 
 #### <code>hier.stan</code>
 
-```{r comment=NA, echo=FALSE}
+```{r echo=FALSE, comment=NA}
 file_path <- "hier.stan";
 lines <- readLines(file_path, encoding="ASCII");
 for (n in 1:length(lines)) cat(lines[n],'\n');
@@ -2709,7 +2821,7 @@ for (n in 1:length(lines)) cat(lines[n],'\n');
 
 #### <code>hier-logit.stan</code>
 
-```{r comment=NA, echo=FALSE}
+```{r echo=FALSE, comment=NA}
 file_path <- "hier-logit.stan";
 lines <- readLines(file_path, encoding="ASCII");
 for (n in 1:length(lines)) cat(lines[n],'\n');

--- a/knitr/pool-binary-trials/pool-no-pool.Rmd
+++ b/knitr/pool-binary-trials/pool-no-pool.Rmd
@@ -1,9 +1,23 @@
-## Hierarchical Partial Pooling for Repeated Binary Trials in CmdStanR
+---
+title: "Hierarchical Partial Pooling for Repeated Binary Trials"
+author: "Bob Carpenter"
+date: "29 January 2016"
+output:
+  html_document:
+    theme: readable
+  pdf_document: default
+---
 
-*Bob Carpenter* <br>
-29 January 2016
+```{css style settings, echo = FALSE}
+blockquote {
+    padding: 10px 20px;
+    margin: 0 0 20px;
+    font-size: 0.9em;
+    border-left: 5px solid #eee;
+}
+```
 
-updated for CmdStanR by Mitzi Morris, 19 January 2022
+*updated for CmdStanR by Mitzi Morris, 19 January 2022*
 
 
 ### Abstract
@@ -11,19 +25,23 @@ updated for CmdStanR by Mitzi Morris, 19 January 2022
 This note illustrates the effects on posterior inference of pooling
 data (aka sharing strength) across items for repeated binary trial
 data.  It provides Stan models and R code to fit and check predictive
-models for three situations: (a) complete pooling, which assumes each
-item is the same, (b) no pooling, which assumes the items are
-unrelated, and (c) partial pooling, where the similarity among the
-items is estimated.  We consider two hierarchical models to estimate
-the partial pooling, one with a beta prior on chance of success and
-another with a normal prior on the log odds of success.  The note
-explains with working examples how to
+models for three situations:
 
-- (i) fit models in [CmdStanR](https://mc-stan.org/cmdstanr) and plot the results in R using ggplot2,
-- (ii) estimate event probabilities,
-- (iii) evaluate posterior predictive densities to evaluate model predictions on held-out data, (iv) rank items by chance of success,
-- (v) perform multiple comparisons in several settings,
-- (vi) replicate new data for posterior p-values, and (vii) perform graphical posterior predictive checks.
+1. complete pooling, which assumes each item is the same
+2. no pooling, which assumes the items are unrelated
+3. partial pooling, where the similarity among the items is estimated.
+   + a hierarchical model with with a *beta prior* on the *chance of success*
+   + a hierarchical model with a *normal prior* on the *log odds of success*
+
+We explain and give working examples of how to:
+
+- fit models in [CmdStanR](https://mc-stan.org/cmdstanr) and plot the results in R using ggplot2,
+- estimate event probabilities,
+- evaluate posterior predictive densities to evaluate model predictions on held-out data
+- rank items by chance of success,
+- perform multiple comparisons in several settings,
+- replicate new data for posterior p-values
+- perform graphical posterior predictive checks.
 
 
 ### Packages used in this notebook
@@ -31,31 +49,34 @@ explains with working examples how to
 In this notebook, we will use the [CmdStanR interface](https://mc-stan.org/cmdstanr/).
 
 ```{r comment=NA}
+# uncomment as needed to install CmdStanR, CmdStan
 #library(devtools);
 #if(!require(cmdstanr)){
 #    devtools::install_github("stan-dev/cmdstanr", dependencies=c("Depends", "Imports"))
 #}
 options(warn=-1)
 options(repr.plot.width=8, repr.plot.height=8)
+options(output.width='90%')
 library(tidyverse)
+library(ggplot2)
 library(posterior)
 library(cmdstanr)
-set_cmdstan_path("/Users/mitzi/.cmdstan/cmdstan-2.28.2")
 ```
 ```{r echo=FALSE}
 theme_jupyter <- function() {
   theme_grey() + 
-  theme(text = element_text(size=18),
-        plot.title = element_text(size=24),
-        plot.subtitle = element_text(size=20),
-        axis.title.x = element_text(size=20),
-        axis.title.y = element_text(size=20),
-        strip.text.x = element_text(size=18),
-        strip.text.y = element_text(size=18)
-       );
+  theme(text = element_text(size=12),
+        plot.title = element_text(size=rel(1.1)),
+        plot.subtitle = element_text(size=rel(1)),
+        axis.title.x = element_text(size=rel(1)),
+        axis.title.y = element_text(size=rel(1)),
+        strip.text.x = element_text(size=rel(.95)),
+        strip.text.y = element_text(size=rel(.95)),
+        axis.text.x = element_text(size=rel(0.9)),
+        axis.text.y = element_text(size=rel(0.9))
+       )
 }
 ```
-
 
 ## Repeated Binary Trials
 
@@ -89,27 +110,16 @@ downloaded 24 Dec 2015 from
 It is drawn from the 1970 Major League Baseball season from both
 leagues.
 
+We will only need a few columns of the data; we will be using
+the remaining hits and at bats to evaluate the predictive inferences for the various models.
+
 ```{r comment=NA}
-df <- read.csv("efron-morris-75-data.tsv", sep="\t");
+df <- read.csv("efron-morris-75-data.tsv", sep="\t")
 df <- with(df, data.frame(FirstName, LastName, 
                           Hits, At.Bats, 
                           RemainingAt.Bats,
-                          RemainingHits = SeasonHits - Hits));
-print(df);
-```
-
-We will only need a few columns of the data; we will be using the
-remaining hits and at bats to evaluate the predictive inferences for
-the various models.
-
-```{r comment=NA}
-M <- 10000  # total draws in the sample
-N <- dim(df)[1]
-K <- df$At.Bats
-y <- df$Hits
-K_new <- df$RemainingAt.Bats;
-y_new <- df$RemainingHits;
-names <- paste(seq(1:18), df$FirstName, df$LastName);
+                          RemainingHits = SeasonHits - Hits))
+print(df)
 ```
 
 The data separates the outcome from the initial 45 at-bats from the
@@ -140,10 +150,23 @@ data {
 }
 ```
 
-As usual, we follow the convention of naming our program
+We follow the convention of naming our program
 variables after the variables we use when we write the model out
-mathematically in a paper.  We also choose capital letters for integer
-constants and y for the main observed variable(s).
+mathematically in a paper.  We choose capital letters for integer
+constants, here <code>N</code> and <code>K</code>, 
+and we use a lowercase <code>y</code> for the main observed variable(s).
+We try to use these abstract names for data and parameters
+instead of dataset-specific names such as "hits" and "at-bats"
+because these basic models are useful in many domains,
+as mentioned above.
+
+Because we shall develop four models all of which use the same
+data and transformed data, we create a Stan program which
+contains just the data and transformed data blocks "data-blocks.stan"
+and use Stan's [include directive](https://mc-stan.org/docs/reference-manual/includes-section.html)
+to use this across all four models.
+Because the models contain <code>#include</code> directives, we need to
+specify the `include_paths` when instantiating or compiling the model.
 
 ## Pooling
 
@@ -234,8 +257,7 @@ as
 
 ```
 model {
-  ...
-  y ~ binomial(K, phi);
+  y ~ binomial(K, phi); // likelihood
 }
 ```
 
@@ -265,39 +287,40 @@ vectorized form can be up to an order of magnitude or more faster in
 some cases, depending on how many repeated calculations can be
 avoided.
 
-The actual Stan program in <code>pool.stan</code> has many more
+The actual Stan program in <code>pool.stan</code> includes many
 derived quantities that will be used in the rest of this note; see
 the appendix for the full code of all of the models discussed.
 
-
-We wish to create a posterior sample of size 10,000 draws.
-To do this we first call the `cmdstan_model()` function which instantiates a CmdStanModel object from a file containing a Stan program.
+We must first instantiate a CmdStanModel object then call its <code>sample</code> method.
+To do this we first call the `cmdstan_model()` function
+which instantiates a CmdStanModel object from a file containing a Stan program.
+Because these models contain a number of [include directives](https://mc-stan.org/docs/reference-manual/includes-section.html), 
+we use the `include_paths` argument to pass in the path to the current directory.
 
 ```{r}
-pool_model <- cmdstan_model(stan_file='pool.stan')
+pool_model <- cmdstan_model(stan_file='pool.stan', include_paths=c('include'))
 ```
 
-draws we first instantiate a
-To fit the model to the dataThe model can be fit as follows, with `M` being the total number of
-draws in the complete posterior sample (each chain is by default split
-into half warmup and half sampling iterations and 4 chains are being
-run).
+We create the R data structures corresponding to the model inputs.
+In addition, we define the desired size of the MCMC sample,
+here we set it to $10,000$ draws.
+```{r comment=NA}
+N <- dim(df)[1]
+K <- df$At.Bats
+y <- df$Hits
+K_new <- df$RemainingAt.Bats
+y_new <- df$RemainingHits
 
-To fit the model we first create a named list containing the values for all input data variables.
+M <- 10000  # total draws in the sample
+```
+We pass the data into the `sample` method as a list of name, value pairs.
 By default, CmdStanR runs 4 chains with 1000 warmup and sampling iterations per chain.
-To generate a sample of 10,000 draws, we specify the per-chain number of sampling iterations to be 2500.
+To generate a sample with a total of $M = 10000$ draws,
+we specify the per-chain sampling iterations to be $M / 4$.
 
 ```{r comment=NA}
-# These were computed in the 2nd code chunk above
-#N <- dim(df)[1]
-#K <- df$At.Bats
-#y <- df$Hits
-#K_new <- df$RemainingAt.Bats;
-#y_new <- df$RemainingHits;
-
 baseball_data = list(N=N, K=K, y=y, K_new=K_new, y_new=y_new)
-fit_pool <- pool_model$sample(data=baseball_data, iter_sampling=2500)
-
+fit_pool <- pool_model$sample(data=baseball_data, iter_sampling=M/4, refresh=0)
 ```
 
 The posterior sample for <code>phi</code> can be summarized as
@@ -353,29 +376,29 @@ parameter $\theta_n \in [0,1]$ for each item $n$.
 
 The prior on each $\theta_n$ is uniform,
 
-$
+$$
 p(\theta_n) = \mathsf{Uniform}(\theta_n \, | \, 0,1),
-$
+$$
 
 and the $\theta_n$ are assumed to be independent, 
 
-$
+$$
 p(\theta) = \prod_{n=1}^N \mathsf{Uniform}(\theta_n \, | \, 0,1).
-$
+$$
 
 The likelihood then uses the chance of success $\theta_n$ for item $n$
 in modeling the number of successes $y_n$ as
 
-$
+$$
 p(y_n \, | \, \theta_n) = \mathsf{Binomial}(y_n \, | \, K_n, \theta_n).
-$
+$$
 
 Assuming the $y_n$ are independent (conditional on $\theta$), this
 leads to the total data likelihood
 
-$
+$$
 p(y \, | \, \theta) = \prod_{n=1}^N \mathsf{Binomial}(y_n \, | \, K_n, \theta_n).
-$
+$$
 
 The Stan program for no pooling only differs in declaring the ability
 parameters as an $N$-vector rather than a scalar.
@@ -411,15 +434,14 @@ in <code>no-pool.stan</code>, which is shown in the appendix.
 This model can be fit the same way as the last model.
 
 ```{r results='hide', comment=NA}
-no_pool_model <- cmdstan_model(stan_file='no-pool.stan')
-fit_no_pool <- no_pool_model$sample(data=baseball_data, iter_sampling=2500)
-
+no_pool_model <- cmdstan_model(stan_file='no-pool.stan', include_paths=c('include'))
+fit_no_pool <- no_pool_model$sample(data=baseball_data, iter_sampling=M/4, refresh=0)
 ```
 
 Now we examine the per-player chance of success `theta`
 
 ```{r comment=NA}
-fit_no_pool$print('theta');
+fit_no_pool$print('theta', max_rows=18)
 ```
 
 Now there is a separate line for each item's estimated $\theta_n$.
@@ -477,10 +499,10 @@ assume a <a
 href="https://en.wikipedia.org/wiki/Beta_distribution">beta
 distribution</a> as the prior as it is scaled to values in $[0, 1]$,
 
-$
+$$
 p(\theta_n \, | \, \alpha, \beta)
 \ = \ \mathsf{Beta}(\theta_n \, | \, \alpha, \beta),
-$
+$$
 
 where $\alpha, \beta > 0$ are the parameters of the prior.  The beta
 distribution is the conjugate prior for the binomial, meaning that the
@@ -492,25 +514,25 @@ observations and thus a uniform distribution.  Each $\theta_n$ will be
 modeled as conditionally independent given the prior parameters, so
 that the complete prior is
 
-$
+$$
 p(\theta \, | \, \alpha, \beta) 
 = \prod_{n=1}^N \mathsf{Beta}(\theta_n \, | \, \alpha, \beta).
-$
+$$
 
 The parameters $\alpha$ and $\beta$ are themselves given priors
 (sometimes called hyperpriors).  Rather than parameterize $\alpha$ and
 $\beta$ directly, we will instead put priors on $\phi \in [0, 1]$
 and $\kappa > 0$, and then define
 
-$
+$$
 \alpha = \kappa \, \phi
-$
+$$
 
 and
 
-$
+$$
 \beta = \kappa \, (1 - \phi).
-$
+$$
 
 This reparameterization is convenient, because 
 
@@ -523,15 +545,15 @@ inversely related to the variance).
 We will follow Gelman et al. (2013, Chapter 5) in providing a prior
 that factors into a uniform prior on $\phi$,
 
-$
+$$
 p(\phi) = \mathsf{Uniform}(\phi \, | \, 0, 1), 
-$
+$$
 
 and a Pareto prior on $\kappa$,
 
-$
+$$
 p(\kappa) = \mathsf{Pareto}(\kappa \, | \, 1, 1.5) \propto \kappa^{-2.5}.
-$
+$$
 
 with the restriction $\kappa > 1$.  In general, for functions $f$ and
 $g$, we write $f(x) \propto g(x)$ if there is some constant $c$ such
@@ -580,22 +602,14 @@ except that this time we set the pseudorandom number generator seed here to 1234
 so that we can consistently generate the exact set of draws.
 
 ```{r results='hide', comment=NA}
-hier_model <- cmdstan_model(stan_file='hier.stan')
-fit_hier <- hier_model$sample(data=baseball_data, iter_sampling=2500, seed=1234)
+hier_model <- cmdstan_model(stan_file='hier.stan', include_paths=c('include'))
+fit_hier <- hier_model$sample(data=baseball_data,
+                              iter_sampling=M/4,
+			      seed=1234,
+			      refresh=0,
+			      show_messages=FALSE)
 ```
-
-The console output contains a number of error messages of the form
-```
-
-Warning: 8 of 10000 (0.0%) transitions ended with a divergence.
-This may indicate insufficient exploration of the posterior distribution.
-Possible remedies include: 
-  * Increasing adapt_delta closer to 1 (default is 0.8) 
-  * Reparameterizing the model (e.g. using a non-centered parameterization)
-  * Using informative or weakly informative prior distributions 
-
-```
-
+The sampler prints a warning about divergent transitions.
 CmdStan's [diagnose](https://mc-stan.org/docs/cmdstan-guide/diagnose.html) utility provides more checks on the MCMC sample.
 
 ```{r}
@@ -652,11 +666,12 @@ target acceptance rate (<code>adapt_delta</code>).
 
 ```{r results='hide', comment=NA}
 fit_hier <- hier_model$sample(data=baseball_data,
-                              iter_sampling=2500,
-                              iter_warmup=2000,
+                              iter_sampling=M/4,
+                              iter_warmup=M/4,
                               seed=1234,
                               step_size=0.01,
-                              adapt_delta=0.95)
+                              adapt_delta=0.95,
+			      refresh=0)
 ```
 
 Now it runs without divergent translations.
@@ -710,9 +725,8 @@ reproduce that figure here for our running example.
 
 ```{r}
 # extract model fit as R dataframe/ tibble for ggplot2
-hier_df = as_draws_df(fit_hier$draws())
+hier_df = fit_hier$draws(format="df");
 
-library(ggplot2);
 bda_plot <- function(df, x_lab, y_lab) {
   ggplot(df, aes(x=x, y=y)) +
     geom_point(shape=19, alpha=0.15) +
@@ -777,11 +791,11 @@ chance-of-success $\theta_n \in [0,1]$.  In this section, we consider
 an alternative parameterization in terms of the log-odds $\alpha_n$, which are
 defined by the logit transform as
 
-$
+$$
 \alpha_n 
 = \mathrm{logit}(\theta_n) 
 = \log \, \frac{\theta_n}{1 - \theta_n}.
-$
+$$
 
 For example, $\theta_n = 0.25$ corresponds to odds of $.25$ to $.75$
 (equivalently, $1$ to $3$), or log-odds of $\log .25 / .75 = -1.1$.
@@ -789,17 +803,17 @@ For example, $\theta_n = 0.25$ corresponds to odds of $.25$ to $.75$
 We will still use a binomial likelihood, only now we have logit as a
 so-called "link" function.
 
-$
+$$
 p(y_n \, | \, K_n, \alpha_n) 
 \ = \ \mathsf{Binomial}(y_n \, | \, K_n, \ \mathrm{logit}^{-1}(\alpha_n))
-$
+$$
 
 The inverse logit function is the logistic sigmoid from which logistic
 regression gets its name,
 
-$
+$$
 \mathrm{logit}^{-1}(\alpha_n) = \frac{1}{1 + \exp(-\alpha_n)} = \theta_n.
-$
+$$
 
 By construction, for any $\alpha_n \in (-\infty, \infty)$,
 $\mathrm{logit}^{-1}(\alpha_n) \in (0, 1)$; the sigmoid converts
@@ -810,24 +824,24 @@ practice, we only know the result will be in $[0, 1]$.
 Stan has a binomial probability function with a built-in logit link
 function, with which we can define the likelihood directly as
 
-$
+$$
 p(y_n \, | \, K_n, \alpha_n) 
 \ = \ \mathsf{BinomialLogit}(y_n \, | \, K_n, \alpha_n)
 \ = \ \mathsf{Binomial}(y_n \, | \, K_n, \ \mathrm{logit}^{-1}(\alpha_n)).
-$
+$$
 
 We use a simple normal hierarchical prior,
 
-$
+$$
 p(\alpha_n \, | \, \mu, \sigma)
 = \mathsf{Normal}(\alpha_n \, | \, \mu, \sigma).
-$
+$$
 
 Then one level up, we use a weakly informative hyperprior for $\mu$,
 
-$
+$$
 p(\mu) = \mathsf{Normal}(\mu \, | \, -1, 1),
-$
+$$
 
 which places 95% of the prior probability for $\mu$ in the interval
 $(-3, 1)$, which inverse-logit transforms to the interval $(0.05,
@@ -838,11 +852,11 @@ value should obviously be changed for other applications.
 The prior scale $\sigma > 0$ can be taken to be a truncated normal
 (half normal, here):
 
-$
+$$
 p(\sigma)
 \ = \ 2 \, \mathsf{Normal}(\sigma \, | \, 0, 1)
 \ \propto \ \mathsf{Normal}(\sigma \, | \, 0, 1).
-$
+$$
 
 This is a fairly broad prior in this case, being on the log-odds
 scale.
@@ -878,8 +892,11 @@ appendix at the end of this document).
 
 ```{r results='hide', comment=NA}
 hier_logit_centered_model <- cmdstan_model(stan_file='hier-logit-centered.stan')
-fit_hier_logit_centered <- hier_logit_centered_model$sample(data=baseball_data, iter_sampling=2500, seed=1234)
-
+fit_hier_logit_centered <- hier_logit_centered_model$sample(data=baseball_data,
+                                                            iter_warmup=M/4,
+							    iter_sampling=M/4,
+							    seed=1234,
+							    refresh=0)
 ```
 
 ```{r comment=NA}
@@ -947,50 +964,62 @@ random-walk Metropolis samplers (Papaspiliopoulos et al. 2003).  This
 basically amounts to changing the parameterization over which sampling
 is done, taking now a standard unit normal prior for a new variable,
 
-$
+$$
 \alpha^{\mathrm{std}}_n = \frac{\alpha_n - \mu}{\sigma}.
-$
+$$
 
 Then we can parameterize in terms of $\alpha^{\mathrm{std}}$, which
 has a standard-normal distribution
 
-$
+$$
 p(\alpha^{\mathrm{std}}_n) = \mathsf{Normal}(\alpha^{\mathrm{std}}_n \, | \, 0, 1).
-$
+$$
 
 We can then define our original $\alpha$ as a derived quantity
 
-$
+$$
 \alpha_n = \mu + \sigma \, \alpha^{\mathrm{std}}_n.
-$
+$$
 
-We code this implicitly in the Stan model by defining the
-likelihood as
+This decouples the sampling distribution
+for $\alpha^{\mathrm{std}}$ from $\mu$ and $\sigma$, greatly reducing
+their correlation in the posterior.  
 
-$
-p(y_n \, | \, \alpha^{\mathrm{std}}_n, \mu, \sigma, K)
-\ = \
-\mathsf{BinomialLogit}(K_n, \ \mu + \sigma \, \alpha_n).
-$
+Prior to Stan 2.19, a Stan implementation directly encoded the math.
+```
+parameters {
+  real mu; // population mean of success log-odds
+  real<lower=0> sigma; // population sd of success log-odds
+  vector[N] alpha_std; // success log-odds (standardized)
+}
+model {
+  vector[N] alpha = mu + sigma * alpha_std;
+  ...
+  alpha_std ~ normal(0, 1); // prior (hierarchical)
+  y ~ binomial_logit(K, alpha); // likelihood
+}
+```
 
-This decouples the sampling distribution for $\alpha^{\mathrm{std}}$
-from $\mu$ and $\sigma$, greatly reducing their correlation in the
-posterior.  
+Since Stan version 2.19, the Stan language's
+[affine transform](https://mc-stan.org/docs/reference-manual/univariate-data-types-and-variable-declarations.html) construct provides a more efficient way to do this.
 
-The Stan program's parameter declaration and model directly follow the
-definition.
+> Real variables may be declared on a space that has been transformed using an affine transformation $x\mapsto \mu + \sigma * x$ with offset $\mu$ and (positive) multiplier $\sigma$, using a syntax similar to that for bounds. While these transforms do not change the asymptotic sampling behaviour of the resulting Stan program (in a sense, the model the program implements), they can be useful for making the sampling process more efficient by transforming the geometry of the problem to a more natural multiplier and to a more natural offset for the sampling process, for instance by facilitating a non-centered parameterisation.
+
+Specifying the affine transform in the parameter declaration for 
+$\alpha^{\mathrm{std}}$ eliminates the need for intermediate variables
+and makes it easier to see the hierarchical structure of the model.
 
 ```
 parameters {
-  real mu;                       // population mean of success log-odds
-  real<lower=0> sigma;           // population sd of success log-odds
-  vector[N] alpha_std;           // success log-odds
+  real mu; // population mean of success log-odds
+  real<lower=0> sigma; // population sd of success log-odds
+  vector<offset=mu, multiplier=sigma>[N] alpha_std; // success log-odds (standardized)
 }
 model {
-  mu ~ normal(-1, 1);                             // hyperprior
-  sigma ~ normal(0, 1);                           // hyperprior
-  alpha_std ~ normal(0, 1);                       // prior
-  y ~ binomial_logit(K, mu + sigma * alpha_std);  // likelihood
+  mu ~ normal(-1, 1); // hyperprior
+  sigma ~ normal(0, 1); // hyperprior
+  alpha_std ~ normal(mu, sigma); // prior (hierarchical)
+  y ~ binomial_logit(K, alpha_std); // likelihood
 }
 ```
 
@@ -1006,10 +1035,7 @@ computed as a generated quantity.
 
 ```
 generated quantities {
-  vector[N] theta;  // chance of success
-  ...
-  for (n in 1:N)
-    theta[n] <- inv_logit(mu + sigma * alpha_std[n]);
+  vector[N] theta = inv_logit(alpha_std);
   ...
 }
 ```
@@ -1020,13 +1046,14 @@ The full Stan program for the hierarchical logistic model is in
 It is fit and the values are extracted as follows.
 
 ```{r results='hide', comment=NA}
-hier_logit_model <- cmdstan_model(stan_file='hier-logit.stan')
+hier_logit_model <- cmdstan_model(stan_file='hier-logit.stan', include_paths=c('include'))
 fit_hier_logit <- hier_logit_model$sample(data=baseball_data,
-                                          iter_sampling=2500,
-                                          iter_warmup=2000,
+                                          iter_sampling=M/4,
+                                          iter_warmup=M/4,
                                           seed=1234,
                                           step_size=0.01,
-                                          adapt_delta=0.99);
+                                          adapt_delta=0.99,
+					  refresh=0)
 ```
 
 We can print as before.
@@ -1037,7 +1064,7 @@ fit_hier_logit$print(c("alpha_std", "theta", "mu", "sigma"), max_rows=100)
 
 It is clear from the wide posteriors for the $\theta_n$ that there is
 considerable uncertainty in the estimates of chance-of-success on an
-item-by-item basis.  With an 90% interval of $(0.02, 0.37)$ for `sigma`,
+item-by-item basis.  With an 90% interval of $(0.02, 0.36)$ for `sigma`,
 it is clear that the data is consistent with complete pooling
 (i.e., $\sigma = 0$).
 
@@ -1094,7 +1121,7 @@ successes $y_n$ for the first $K_n$ trials versus the median and 80\%
 intervals for the estimated chance-of-success parameters $\theta_n$ in
 the posterior.  The following R code reproduces a similar plot for our data.
 
-```{r}
+```{r, out.width="110%"}
 # summary statistics - quantiles 10%, 50%, 90%
 ss_quantiles <- function(draws_df) {
   apply(select(draws_df, starts_with('theta')), 2, quantile, probs = c(0.1, 0.5, 0.9));
@@ -1334,22 +1361,22 @@ intervals (Gneiting et al. 2007).
 
 The log of posterior predictive density is defined in the obvious way as
 
-$
+$$
 \log p(\tilde{y} \, | \, y)
 = \log \int_{\Theta} p(\tilde{y} \, | \, \theta) 
                      \ p(\theta \, | \, y)
                      \ \mathrm{d}\theta.
-$
+$$
 
 This is not a posterior expectation, but rather the log of a posterior
 expectation.  In particular, it should not be confused with the
 posterior expectation of the log predictive density, which is given by
 
-$
+$$
  \int_{\Theta} \left( \log p(\tilde{y} \, | \, \theta) \right) 
                \ p(\theta \, | \, y)  
                \ \mathrm{d}\theta.
-$
+$$
 
 Although this is easy to compute in Stan in a stable fashion, it does
 not produce the same answer (as we show below).
@@ -1359,11 +1386,11 @@ inequality](https://en.wikipedia.org/wiki/Jensen%27s_inequality) shows
 that the expectation of the log is less than or equal to the log of
 the expectation,
 
-$
+$$
 \log \int_{\Theta} p(\tilde{y} \, | \, \theta) \ p(\theta \, | \, y) \ \mathrm{d}\theta
 \ \leq \
 \int_{\Theta} \left( \, \log p(\tilde{y} \, | \, \theta) \, \right) \ p(\theta \, | \, y) \ \mathrm{d}\theta.
-$
+$$
 
 We'll compute both expectations and demonstrate Jensen's inequality in
 our running example.
@@ -1372,31 +1399,39 @@ The integer variables <code>K_new[n]</code> and <code>y_new[n]</code>
 declared in the data block hold the number of at bats (trials) 
 and the number of hits (successes) for player (item) <code>n</code>.
 To code the evaluation of the held out data in Stan, we declare a
-generated quantities variable (<code>log_p_news</code>) to hold the
-log density of each data point and define it in the obvious way.
+generated quantities variable (<code>log_p_new</code>)
+which is the sum of the per-item posterior predictive log densities.
 
+Because we are computing this quantity across all models,
+we put the code into its own file named "gq-postpred.stan"
+and Stan's include directive in all models.
+Include directive in the model's <code>generated quantities</code> block.
 ```
 generated quantities {
   ...
-  real log_p_new;        // posterior predictive log density remaining trials
-  vector[N] log_p_news;  // posterior predictive log density for item
-  ...
-  for (n in 1:N)
-    log_p_news[n] <- binomial_log(y_new[n], K_new[n], theta[n]);
-  log_p_new <- sum(log_p_news);
+  #include gq-postpred.stan
   ...
 }
 ```
 
+First we compute the posterior predictive density for the remaining trials.
+```
+  // posterior predictive log density remaining trials
+  real log_p_new = 0;
+  for (n in 1 : N) {
+    log_p_new = log_p_new + binomial_lpmf(y_new[n] | K_new[n], theta[n]);
+  }
+```
+    
 The posterior mean for <code>log_p_new</code> will give us
 
-$
+$$
  \int_{\Theta} \left( \log p(\tilde{y} \, | \, \theta) \right) 
                \ p(\theta \, | \, y)  
                \ \mathrm{d}\theta
 \ \approx \
 \frac{1}{M} \, \sum_{m=1}^M \log p(y^{\mathrm{new}} \, | \, \theta^{(m)}).
-$
+$$
 
 This calculation is included in all four of the models we have
 previously fit and can be displayed directly as follows as the
@@ -1422,11 +1457,11 @@ The straight path to calculate this would be to define a generated
 quantity $p(y^{\mathrm{new}} \, | y)$, look at the posterior mean
 computed by Stan, and takes its log.   That is, 
 
-$
+$$
 \log p(y^{\mathrm{new}} \, | \, y)
 \ \approx \
 \log \frac{1}{M} \, \sum_{m=1}^M p(y^{\mathrm{new}} \, | \, \theta^{(m)}).
-$
+$$
 
 Unfortunately, this won't work in most cases because when we try to
 compute $p(y^{\mathrm{new}} \, | \, \theta^{(m)})$ directly, it is prone
@@ -1446,32 +1481,32 @@ To avoid underflow, we're going to use the
 [log-sum-of-exponentials](https://en.wikipedia.org/wiki/LogSumExp)
 trick, which begins by noting the obvious,
 
-$
+$$
 \log \frac{1}{M} \, \sum_{m=1}^M \ p(y^{\mathrm{new}} \, | \, \theta^{(m)}).
 \ = \
 \log \frac{1}{M} \, \sum_{m=1}^M
                      \ \exp \left( \log p(y^{\mathrm{new}} \, | \, \theta^{(m)}) \right).
-$
+$$
 
 We'll then write that last expression as
 
-$
+$$
 -\log M 
 +  \mathrm{log\_sum\_exp \, }_{m=1}^M
         \ \log p(y^{\mathrm{new}} \, | \, \theta^{(m)})
-$
+$$
 
 We can compute $\mathrm{log\_sum\_exp}$ stably by subtracting the max value.
 Suppose $u = u_1, \ldots, u_M$, and $\max(u)$ is the largest $u_m$.
 We can calculate
 
-$
+$$
 \mathrm{log\_sum\_exp \, }_{m=1}^M \ u_m
 \ = \
 \log \sum_{m=1}^M \exp(u_m)
 \ = \
 \max(u) + \log \sum_{m=1}^M \exp(u_m - \max(u)).
-$
+$$
 
 Because $u_m - \max(u) \leq 0$, the exponentiations cannot overflow.
 They may underflow to zero, but this will not lose precision because
@@ -1531,14 +1566,7 @@ pseudorandom number generator, which corresponds to the binomial
 sampling distribution (likelihood) in this case.
 
 ```
-generated quantities {
-  ...
-  int<lower=0> z[N];  // posterior prediction remaining trials
-  ...
-  for (n in 1:N)
-    z[n] <- binomial_rng(K_new[n], theta[n]);
-  ...
-}
+  array[N] int<lower=0> z = binomial_rng(K_new, theta);
 ```
 
 This formulation makes it clear that there are two sources of
@@ -1562,8 +1590,14 @@ sense we define below).
 The number of remaining at-bats $K^{\mathrm{new}}$ was printed out in
 the original table along with the actual number of hits.
 
-```{r comment=NA}
-fit_pool$print('z', max_rows=18)
+```{r}
+print(df)
+```
+
+We examine the 80% intervals on the basic hierarchical model for <code>z</code>, the posterior predictions for the rest of the season.
+
+```{r}
+fit_hier$print('z', "mean", "median", ~quantile(.x, probs = c(0.1, 0.9)), max_rows=18)
 ```
 
 Translating the posterior number of hits into a season batting
@@ -1571,7 +1605,7 @@ average, $\frac{y_n + z_n}{K_n + K^{\mathrm{new}}_n}$,
 we get an 80% posterior interval of
 
 $$
-\left( \frac{18 + 93}{45 + 367}, \frac{18 + 147}{45 + 367} \right) 
+\left( \frac{18 + 93}{45 + 367}, \frac{18 + 145}{45 + 367} \right) 
 \ = \
 (0.269, 0.400).
 $$
@@ -1600,7 +1634,7 @@ predictive 50% interval for predicted batting average (success rate)
 in his remaining at bats (trials); the observed success rate in the
 remainder of the season is shown as a blue dot.
 
-```{r comment=NA}
+```{r comment=NA, out.width="110%"}
 # N is number of players
 y_new_25_pool <- c(NA, N);
 y_new_25_no_pool <- c(NA, N);
@@ -1747,7 +1781,7 @@ over parameters and data. For example, the probability of player $n$'s
 batting average being 0.400 or better conditioned on the data $y$ is
 defined by the conditional event probability
 
-$
+$$
 \mathrm{Pr}\left[
 \frac{(y_n + z_n)}{(45 + K^{\mathrm{new}}_n)} \geq 0.400 
 \, \Big| \, 
@@ -1759,19 +1793,19 @@ y
        \ p(z_n \, | \, \theta_n, K^{\mathrm{new}}_n)
        \ p(\theta \, | \, y, K)
        \ \mathrm{d}\theta.
-$
+$$
 
 The indicator function $\mathrm{I}[c]$ evaluates to 1 if the condition
 $c$ is true and 0 if it is false.  Because it is just another
 expectation with respect to the posterior, we can calculate this event
 probability using MCMC as
 
-$
+$$
 \mathrm{Pr}\left[\frac{(y_n + z_n)}{(45 + K^{\mathrm{new}}_n)} \geq
 0.400 \, \Big| \, y \right]
 \ \approx \
 \frac{1}{M} \, \sum_{m=1}^M \mathrm{I}\left[\frac{(y_n + z_n^{(m)})}{(45 + K^{\mathrm{new}}_n)} \geq 0.400\right].
-$
+$$
 
 This event is about the season batting average being greater than
 0.400.  What if we care about ability (chance of success), not batting
@@ -1780,7 +1814,7 @@ the question of whether $\mathrm{Pr}[\theta_n > 0.4]$.  This is
 defined as a weighted average over the prior and computed via MCMC as
 the previous case.
 
-$
+$$
 \mathrm{Pr}\left[\theta_n \geq 0.400 \, | \, y \right]
 \ = \
 \int_{\Theta}
@@ -1789,25 +1823,26 @@ $
        \ \mathrm{d}\theta
 \ \approx \
 \frac{1}{M} \, \sum_{m=1}^M \mathrm{I}[\theta_n^{(m)} \geq 0.400].
-$
+$$
 
-In Stan, we just declare and define the indicators directly in the
-generated quantities block.
-
+This logic is part of the include file `gq-postpred.stan`.
 ```
-generated quantities {
-  ...
-  int<lower=0, upper=1> some_ability_gt_350;  // Pr[some theta > 0.35]
-  int<lower=0, upper=1> avg_gt_400[N];        // Pr[season avg of n] >= 0.400
-  int<lower=0, upper=1> ability_gt_400[N];    // Pr[chance-of-success of n] >= 0.400
-  ...
-  some_ability_gt_350 <- (max(theta) > 0.35);
-  for (n in 1:N)
-    avg_gt_400[n] <- (((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400);
-  for (n in 1:N)
-    ability_gt_400[n] <- (theta[n] > 0.400);
-  ...
-}
+  // posterior predictions on new data
+  array[N] int<lower=0> z = binomial_rng(K_new, theta); 
+
+  // Pr[some theta > 0.35]  
+  int<lower=0, upper=1> some_ability_gt_350 = max(theta) > 0.35;
+  // Pr[some player ability > 400]
+  array[N] int<lower=0, upper=1> ability_gt_400;
+  for (n in 1 : N) {
+    ability_gt_400[n] = theta[n] > 0.400;
+  }
+  // Pr[some player season average > 400]
+  array[N] int<lower=0, upper=1> avg_gt_400;
+  for (n in 1 : N) {
+    // y[n] - observed, z[n] - expected hits in rest of season
+    avg_gt_400[n] = ((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400;
+  }
 ```
 
 The indicator function is not explicitly specified because Stan's
@@ -1827,11 +1862,6 @@ sample size estimate and no evidence of non-convergence in the form
 for $\hat{R}$ values much greater than 1.  The NaN values in the
 $\hat{R}$ column arise when every posterior draw is the same; there is
 zero sample variance, and so $\hat{R}$ is not defined.
-
-```{r comment=NA}
-# players of interest
-message(c(names[1], "\n", names[5], "\n", names[10]));
-```
 
 ```{r comment=NA}
 pars_to_print <- c("some_ability_gt_350", 
@@ -1947,19 +1977,21 @@ rank (a value ranging from $1$ to $N$) of the second player.  First,
 we define a local variable <code>dsc</code>, and sort it into
 descending order.
 
+We encapsulate this logic into its own program file "gq-ranking.stan"
+and include it in the model's generated quantities block.
 ```
-generated quantities {
-  ...
-  int<lower=1, upper=N> rnk[N];   // rnk[n] is rank of player n
-  ...
+  array[N] int<lower=1, upper=N> rnk; // rank of player n
   {
-    int dsc[N];
-    dsc <- sort_indices_desc(theta);
-    for (n in 1:N)
-      rnk[dsc[n]] <- n;
+    array[N] int dsc;
+    dsc = sort_indices_desc(theta);
+    for (n in 1 : N) {
+      rnk[dsc[n]] = n;
+    }
   }
-  ...
-}
+  array[N] int<lower=0, upper=1> is_best; // Pr[player n highest chance of success]
+  for (n in 1 : N) {
+    is_best[n] = rnk[n] == 1;
+  }
 ```
 
 After the call to <code>sort_indices_desc</code>, <code>dsc[n]</code>
@@ -1981,7 +2013,7 @@ pooling model, where every player is assumed to have the same ability.
 We can print just the ranks and the 80% central interval for the basic pooling model.
 
 ```{r comment=NA}
-fit_hier$print("rnk", max_rows=18);
+fit_hier$print("rnk", "mean", "median", ~quantile(.x, probs = c(0.1, 0.9)), max_rows=18);
 ```
 
 It is again abundantly clear from the posterior intervals that our
@@ -1993,8 +2025,7 @@ mortality, the posterior distribution over ranks was plotted for each
 hospital.  It is now straightforward to reproduce that figure here for
 the baseball data.
 
-```{r comment=NA}
-library(ggplot2);
+```{r comment=NA, out.width="110%"}
 rnk_hier <- matrix(fit_hier$draws('rnk'), M, N);
 df_rank <- data.frame(list(name = rep(as.character(df[[1,2]]), M),
                            rank = rnk_hier[, 1]));
@@ -2013,7 +2044,7 @@ rank_plot <-
                    labels=c("0.0", "0.1", "0.2")) + 
   ggtitle("Rankings for Partial Pooling Model") +
   theme_jupyter();
-options(repr.plot.width=20, repr.plot.height=16)
+#options(repr.plot.width=20, repr.plot.height=16)
 rank_plot;
 ```
 
@@ -2048,18 +2079,13 @@ already computed or we could compute it directly as above.  Because
 $\mathrm{Pr}[\theta_n = \theta_{n'}] = 0$ for $n \neq n'$, we don't
 have to worry about ties.
 
-We define a new generated quantity for the value of the indicator and
-define it using the already-computed ranks.
-
+The generated quantities variable `is_best` is defined
+using the already-computed ranks.
 ```
-generated quantities {
-  ...
-  int<lower=0, upper=1> is_best[N];  // Pr[player n highest chance of success]
-  ...
-  for (n in 1:N)
-    is_best[n] <- (rnk[n] == 1);
-  ...
-}
+  array[N] int<lower=0, upper=1> is_best; // Pr[player n highest chance of success]
+  for (n in 1 : N) {
+    is_best[n] = rnk[n] == 1;
+  }
 ```
 
 This means that <code>is_best[n]</code> will be 1 if player
@@ -2075,7 +2101,7 @@ probability.
 
 We can then plot the results for the four models.
 
-```{r comment=NA}
+```{r comment=NA, out.width="80%"}
 df_is_best_for <- function(name, draws) {
   is_best <- rep(NA, N);
   for (n in 1:N) {
@@ -2100,7 +2126,7 @@ is_best_plot <-
   scale_x_discrete(name="player", breaks=c(1, 5, 10, 15)) +
   ggtitle("Who is the Best Player?") +
   theme_jupyter();
-options(repr.plot.width=12, repr.plot.height=4)
+#options(repr.plot.width=12, repr.plot.height=4)
 is_best_plot;
 ```
 
@@ -2196,7 +2222,7 @@ p_B
 \mathrm{I}[T(y^{\mathrm{rep} \ (m)}) \geq T(y)].
 $$
 
-<!-- #region -->
+
 In Stan, the test statistics are first defined for the observed data.
 Because they are functions purely of variables defined in the data
 block, they can be defined in the transformed data block so that they
@@ -2212,46 +2238,38 @@ transformed data {
   real sd_y = sd(to_vector(y));    // sample std dev successes
 }
 ```
-
-The code to generate the replicated data is in the generated
-quantities block.
-
-```
-generated quantities {
-  ...
-  array[N] int<lower=0> y_rep = binomial_rng(K, theta);
-  ...
-}
-```
-
-Then the posterior predictive test statistics are defined in the generated quantities
-block and the actual $p$-value indicators are computed and assigned to
-integer values.  The calls to <code>to_vector()</code> convert an
+The calls to <code>to_vector()</code> convert an
 array of integers to an array of real values so that they are
 appropriately typed to be the input to the standard deviation
 calculation.
 
+Then the posterior predictive test statistics are defined in the generated quantities
+block and the actual $p$-value indicators are computed and assigned to
+integer values. 
+The last part of included file "gq-postpred.stan" computes these values.
 ```
-generated quantities {
-  ...
+  // replications for existing items  
+  array[N] int<lower=0> y_rep = binomial_rng(K, theta);
+  
+  // posterior predictive min replicated successes, test stat p_val
   real<lower=0> min_y_rep = min(y_rep);
   int<lower=0, upper=1> p_min = min_y_rep >= min_y;
 
-  real<lower=0> max_y_rep = max(y_rep);
+  // posterior predictive max replicated successes, test stat p_val
+  real<lower=0> max_y_rep = max(y_rep); 
   int<lower=0, upper=1> p_max = max_y_rep >= max_y;
-  
+
+  // posterior predictive sample mean replicated successes, test stat p_val
   real<lower=0> mean_y_rep = mean(to_vector(y_rep));
   int<lower=0, upper=1> p_mean = mean_y_rep >= mean_y;
 
+  // posterior predictive sample std dev replicated successes, test stat p_val
   real<lower=0> sd_y_rep = sd(to_vector(y_rep));
   int<lower=0, upper=1> p_sd = sd_y_rep >= sd_y;
-}
 ```
-
 
 The fit from the Stan program can then be used to display the Bayesian
 $p$-values for each of the models.
-<!-- #endregion -->
 
 ```{r comment=NA}
 pars_to_print <- c("p_min", "p_max", "p_mean", "p_sd");
@@ -2278,7 +2296,7 @@ shows the posterior predictive distribution for the test statistic,
 the observed value as a vertical line, and the p-value for each of the
 tests.  Here is the plot for the basic hierarchical model.
 
-```{r comment=NA}
+```{r comment=NA, out.width="120%"}
 y_min <- min(y);
 y_max <- max(y);
 y_mean <- mean(y);
@@ -2321,7 +2339,7 @@ post_test_stat_plot <-
              colour = "blue", size = 0.5) +
   ggtitle("Posterior p-values") +
   theme_jupyter();
-options(repr.plot.width=16, repr.plot.height=16)
+#options(repr.plot.width=16, repr.plot.height=16)
 post_test_stat_plot;
 ```
 
@@ -2827,4 +2845,27 @@ lines <- readLines(file_path, encoding="ASCII");
 for (n in 1:length(lines)) cat(lines[n],'\n');
 ```
 
+####  <code>data-blocks.stan</code>
+
+```{r echo=FALSE, comment=NA}
+file_path <- "include/data-blocks.stan";
+lines <- readLines(file_path, encoding="ASCII");
+for (n in 1:length(lines)) cat(lines[n],'\n');
+```
+
+####  <code>include-gq-postpred.stan</code>
+
+```{r echo=FALSE, comment=NA}
+file_path <- "include/gq-postpred.stan";
+lines <- readLines(file_path, encoding="ASCII");
+for (n in 1:length(lines)) cat(lines[n],'\n');
+```
+
+####  <code>include-gq-ranking.stan</code>
+>
+```{r echo=FALSE, comment=NA}
+file_path <- "include/gq-ranking.stan";
+lines <- readLines(file_path, encoding="ASCII");
+for (n in 1:length(lines)) cat(lines[n],'\n');
+```
 

--- a/knitr/pool-binary-trials/pool.stan
+++ b/knitr/pool-binary-trials/pool.stan
@@ -24,58 +24,47 @@ model {
   y ~ binomial(K, phi); // likelihood
 }
 generated quantities {
-  vector<lower=0, upper=1>[N] theta; // chance-of-success
-  
-  real log_p_new; // posterior predictive log density remaining trials
-  
-  array[N] int<lower=0> z; // posterior prediction remaining trials
-  
-  int<lower=0, upper=1> some_ability_gt_350; // Pr[some theta > 0.35]
-  array[N] int<lower=0, upper=1> avg_gt_400; // Pr[season avg of n] >= 0.400
-  array[N] int<lower=0, upper=1> ability_gt_400; // Pr[chance-of-success of n] >= 0.400
-  
-  array[N] int<lower=0> y_rep; // replications for existing items
-  
-  real<lower=0> min_y_rep; // posterior predictive min replicated successes
-  real<lower=0> max_y_rep; // posterior predictive max replicated successes
-  real<lower=0> mean_y_rep; // posterior predictive sample mean replicated successes
-  real<lower=0> sd_y_rep; // posterior predictive sample std dev replicated successes
-  
-  int<lower=0, upper=1> p_min; // posterior predictive p-values
-  int<lower=0, upper=1> p_max;
-  int<lower=0, upper=1> p_mean;
-  int<lower=0, upper=1> p_sd;
-  
-  theta = rep_vector(phi, N);
-  
-  log_p_new = 0;
+  // per-player chance-of-success
+  vector<lower=0, upper=1>[N] theta = rep_vector(phi, N);
+
+  // posterior predictive log density remaining trials (pooled)
+  real log_p_new = 0; 
   for (n in 1 : N) {
     log_p_new = log_p_new + binomial_lpmf(y_new[n] | K_new[n], theta[n]);
   }
   
-  for (n in 1 : N) {
-    z[n] = binomial_rng(K_new[n], theta[n]);
-  }
-  
-  some_ability_gt_350 = max(theta) > 0.35;
+  // posterior predictive remaining trials
+  array[N] int<lower=0> z = binomial_rng(K_new, theta); 
+
+  // Pr[theta > 0.35] (pooled)
+  int<lower=0, upper=1> some_ability_gt_350 = phi > 0.35; 
+
+  // Pr[some player avgerage/ability > 400]
+  array[N] int<lower=0, upper=1> avg_gt_400;
   for (n in 1 : N) {
     avg_gt_400[n] = ((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400;
   }
+  array[N] int<lower=0, upper=1> ability_gt_400;
   for (n in 1 : N) {
     ability_gt_400[n] = theta[n] > 0.400;
   }
+
+  // replications for existing items  
+  array[N] int<lower=0> y_rep = binomial_rng(K, theta);
   
-  for (n in 1 : N) {
-    y_rep[n] = binomial_rng(K[n], theta[n]);
-  }
-  
-  min_y_rep = min(y_rep);
-  max_y_rep = max(y_rep);
-  mean_y_rep = mean(to_vector(y_rep));
-  sd_y_rep = sd(to_vector(y_rep));
-  
-  p_min = min_y_rep >= min_y;
-  p_max = max_y_rep >= max_y;
-  p_mean = mean_y_rep >= mean_y;
-  p_sd = sd_y_rep >= sd_y;
+  // posterior predictive min replicated successes
+  real<lower=0> min_y_rep = min(y_rep);
+  int<lower=0, upper=1> p_min = min_y_rep >= min_y;
+
+  // posterior predictive max replicated successes
+  real<lower=0> max_y_rep = max(y_rep); 
+  int<lower=0, upper=1> p_max = max_y_rep >= max_y;
+
+  // posterior predictive sample mean replicated successes
+  real<lower=0> mean_y_rep = mean(to_vector(y_rep));
+  int<lower=0, upper=1> p_mean = mean_y_rep >= mean_y;
+
+  // posterior predictive sample std dev replicated successes
+  real<lower=0> sd_y_rep = sd(to_vector(y_rep));
+  int<lower=0, upper=1> p_sd = sd_y_rep >= sd_y;
 }

--- a/knitr/pool-binary-trials/pool.stan
+++ b/knitr/pool-binary-trials/pool.stan
@@ -1,22 +1,4 @@
-data {
-  int<lower=0> N; // items
-  array[N] int<lower=0> K; // initial trials
-  array[N] int<lower=0> y; // initial successes
-  
-  array[N] int<lower=0> K_new; // new trials
-  array[N] int<lower=0> y_new; // new successes
-}
-transformed data {
-  real min_y; // minimum successes
-  real max_y; // maximum successes
-  real mean_y; // sample mean successes
-  real sd_y; // sample std dev successes
-  
-  min_y = min(y);
-  max_y = max(y);
-  mean_y = mean(to_vector(y));
-  sd_y = sd(to_vector(y));
-}
+#include data-blocks.stan
 parameters {
   real<lower=0, upper=1> phi; // chance of success (pooled)
 }
@@ -24,47 +6,8 @@ model {
   y ~ binomial(K, phi); // likelihood
 }
 generated quantities {
-  // per-player chance-of-success
+  // define theta, per-player chance-of-success
   vector<lower=0, upper=1>[N] theta = rep_vector(phi, N);
 
-  // posterior predictive log density remaining trials (pooled)
-  real log_p_new = 0; 
-  for (n in 1 : N) {
-    log_p_new = log_p_new + binomial_lpmf(y_new[n] | K_new[n], theta[n]);
-  }
-  
-  // posterior predictive remaining trials
-  array[N] int<lower=0> z = binomial_rng(K_new, theta); 
-
-  // Pr[theta > 0.35] (pooled)
-  int<lower=0, upper=1> some_ability_gt_350 = phi > 0.35; 
-
-  // Pr[some player avgerage/ability > 400]
-  array[N] int<lower=0, upper=1> avg_gt_400;
-  for (n in 1 : N) {
-    avg_gt_400[n] = ((y[n] + z[n]) / (0.0 + K[n] + K_new[n])) > 0.400;
-  }
-  array[N] int<lower=0, upper=1> ability_gt_400;
-  for (n in 1 : N) {
-    ability_gt_400[n] = theta[n] > 0.400;
-  }
-
-  // replications for existing items  
-  array[N] int<lower=0> y_rep = binomial_rng(K, theta);
-  
-  // posterior predictive min replicated successes
-  real<lower=0> min_y_rep = min(y_rep);
-  int<lower=0, upper=1> p_min = min_y_rep >= min_y;
-
-  // posterior predictive max replicated successes
-  real<lower=0> max_y_rep = max(y_rep); 
-  int<lower=0, upper=1> p_max = max_y_rep >= max_y;
-
-  // posterior predictive sample mean replicated successes
-  real<lower=0> mean_y_rep = mean(to_vector(y_rep));
-  int<lower=0, upper=1> p_mean = mean_y_rep >= mean_y;
-
-  // posterior predictive sample std dev replicated successes
-  real<lower=0> sd_y_rep = sd(to_vector(y_rep));
-  int<lower=0, upper=1> p_sd = sd_y_rep >= sd_y;
+  #include gq-postpred.stan
 }


### PR DESCRIPTION
Updated models and notebook for Stan case study "Hierarchical Partial Pooling for Repeated Binary Trials"

- use affine transform for non-centered hierarchical logit model
- use include directives for data, transformed data, and generated quantities code shared across all models
- rework Rmd notebook so that it runs with CmdStanR
